### PR TITLE
Add strong rcv-handler linkage constraints

### DIFF
--- a/src/main/java/pt/haslab/spider/CheckerParallel.java
+++ b/src/main/java/pt/haslab/spider/CheckerParallel.java
@@ -1,6 +1,5 @@
 package pt.haslab.spider;
 
-import java.io.IOException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -11,78 +10,95 @@ import org.json.JSONException;
 import pt.haslab.spider.solver.Z3SolverParallel;
 import pt.haslab.taz.TraceProcessor;
 
-public class CheckerParallel {
-  public static void main(String[] args) throws IOException, JSONException {
-    Options options = new Options();
-    options.addOption(
-        "r",
-        "removeRedundancy",
-        false,
-        "Removes redundant events before checking for race conditions.");
-    options.addOption("d", "dataRaces", false, "Check for data races.");
-    options.addOption("m", "messageRaces", false, "Check for message races.");
-    options.addOption("f", "file", true, "File containing the distributed trace.");
-    options.addOption("s", "solver", true, "SMT solver used.");
-    CommandLineParser parser = new DefaultParser();
-    String traceFilePath = null;
-    CommandLine cmd = null;
+import java.io.IOException;
 
-    try {
-      cmd = parser.parse(options, args);
-      if (!cmd.hasOption("f")) {
-        throw new ParseException("No file path specified.");
-      }
-      traceFilePath = cmd.getOptionValue("f");
-    } catch (ParseException e) {
-      System.err.println("Error: " + e);
-      HelpFormatter formatter = new HelpFormatter();
-      formatter.printHelp("java -jar spider", options);
-      System.exit(1);
+public class CheckerParallel
+{
+    public static void main( String[] args )
+                    throws IOException, JSONException
+    {
+        Options options = new Options();
+        options.addOption(
+                        "r",
+                        "removeRedundancy",
+                        false,
+                        "Removes redundant events before checking for race conditions." );
+        options.addOption( "d", "dataRaces", false, "Check for data races." );
+        options.addOption( "m", "messageRaces", false, "Check for message races." );
+        options.addOption( "f", "file", true, "File containing the distributed trace." );
+        options.addOption( "s", "solver", true, "SMT solver used." );
+        CommandLineParser parser = new DefaultParser();
+        String traceFilePath = null;
+        CommandLine cmd = null;
+
+        try
+        {
+            cmd = parser.parse( options, args );
+            if ( !cmd.hasOption( "f" ) )
+            {
+                throw new ParseException( "No file path specified." );
+            }
+            traceFilePath = cmd.getOptionValue( "f" );
+        }
+        catch ( ParseException e )
+        {
+            System.err.println( "Error: " + e );
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printHelp( "java -jar spider", options );
+            System.exit( 1 );
+        }
+
+        TraceProcessor trace = TraceProcessor.INSTANCE;
+        trace.loadEventTrace( traceFilePath );
+        Stats.INSTANCE.numEventsTrace = trace.getNumberOfEvents();
+        // aggregate partitioned messages to facilitate message race detection
+        trace.aggregateAllPartitionedMessages();
+
+        if ( cmd.hasOption( "r" ) )
+        {
+            RedundantEventPruner eventPruner = new RedundantEventPruner( trace );
+            Stats.INSTANCE.redundantEvents = eventPruner.removeRedundantRW();
+            Stats.INSTANCE.redundantMsgEvents = eventPruner.removeRedundantInterThreadEvents();
+        }
+
+        Z3SolverParallel solver;
+        if ( cmd.hasOption( "s" ) )
+        {
+            solver = initSolver( cmd.getOptionValue( "s" ) );
+        }
+        else
+        {
+            solver = initSolver( "z3" );
+        }
+
+        RaceDetector raceDetector = new RaceDetector( solver, trace );
+        raceDetector.generateConstraintModel();
+
+        // Instead of using 'raceDetector.checkConflicts()' to check all kinds of conflicts, it
+        // executes the analysis for data races and message races depending on the program flags
+        if ( cmd.hasOption( "d" ) )
+        {
+            raceDetector.genDataRaceCandidates();
+            raceDetector.computeActualDataRaces();
+        }
+
+        if ( cmd.hasOption( "m" ) )
+        {
+            raceDetector.genMsgRaceCandidates();
+            raceDetector.computeActualMsgRaces();
+        }
+
+        solver.flush();
+        solver.close();
+        System.out.println( Stats.getInstance().getSummary() );
     }
 
-    TraceProcessor trace = TraceProcessor.INSTANCE;
-    trace.loadEventTrace(traceFilePath);
-    Stats.INSTANCE.numEventsTrace = trace.getNumberOfEvents();
-    // aggregate partitioned messages to facilitate message race detection
-    trace.aggregateAllPartitionedMessages();
-
-    if (cmd.hasOption("r")) {
-      RedundantEventPruner eventPruner = new RedundantEventPruner(trace);
-      Stats.INSTANCE.redundantEvents = eventPruner.removeRedundantRW();
-      Stats.INSTANCE.redundantMsgEvents = eventPruner.removeRedundantInterThreadEvents();
+    public static Z3SolverParallel initSolver( String solverPath )
+                    throws IOException
+    {
+        // Solver path is now set to be z3
+        Z3SolverParallel solver = Z3SolverParallel.getInstance();
+        solver.init( solverPath );
+        return solver;
     }
-
-    Z3SolverParallel solver;
-    if (cmd.hasOption("s")) {
-      solver = initSolver(cmd.getOptionValue("s"));
-    } else {
-      solver = initSolver("z3");
-    }
-
-    RaceDetector raceDetector = new RaceDetector(solver, trace);
-    raceDetector.generateConstraintModel();
-
-    // Instead of using 'raceDetector.checkConflicts()' to check all kinds of conflicts, it
-    // executes the analysis for data races and message races depending on the program flags
-    if (cmd.hasOption("d")) {
-      raceDetector.genDataRaceCandidates();
-      raceDetector.computeActualDataRaces();
-    }
-
-    if (cmd.hasOption("m")) {
-      raceDetector.genMsgRaceCandidates();
-      raceDetector.computeActualMsgRaces();
-    }
-
-    solver.flush();
-    solver.close();
-    System.out.println(Stats.getInstance().getSummary());
-  }
-
-  public static Z3SolverParallel initSolver(String solverPath) throws IOException {
-    // Solver path is now set to be z3
-    Z3SolverParallel solver = Z3SolverParallel.getInstance();
-    solver.init(solverPath);
-    return solver;
-  }
 }

--- a/src/main/java/pt/haslab/spider/RaceDetector.java
+++ b/src/main/java/pt/haslab/spider/RaceDetector.java
@@ -1,17 +1,6 @@
 package pt.haslab.spider;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.stream.Collectors;
-
+import com.sun.tools.javac.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pt.haslab.spider.solver.Z3SolverParallel;
@@ -25,508 +14,612 @@ import pt.haslab.taz.events.SocketEvent;
 import pt.haslab.taz.events.SyncEvent;
 import pt.haslab.taz.events.ThreadCreationEvent;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+
 import static pt.haslab.taz.events.EventType.NOTIFYALL;
-import static pt.haslab.taz.events.EventType.RCV;
 
-class RaceDetector {
+class RaceDetector
+{
 
-  private static final Logger logger = LoggerFactory.getLogger(RaceDetector.class);
-  private HashSet<CausalPair<? extends Event, ? extends Event>> dataRaceCandidates;
-  private HashSet<CausalPair<? extends Event, ? extends Event>> msgRaceCandidates;
-  // HB model, used to encode message arrival constraints
-  private HashMap<SocketEvent, Event> rcvNextEvent;
-  private Z3SolverParallel solver;
-  private TraceProcessor traceProcessor;
+    private static final Logger logger = LoggerFactory.getLogger( RaceDetector.class );
 
-  public RaceDetector(Z3SolverParallel solver, TraceProcessor traceProcessor) {
-    dataRaceCandidates = new HashSet<>();
-    msgRaceCandidates = new HashSet<>();
-    rcvNextEvent = new HashMap<>();
-    this.solver = solver;
-    this.traceProcessor = traceProcessor;
-  }
+    private HashSet<CausalPair<? extends Event, ? extends Event>> dataRaceCandidates;
 
-  // TODO: use the same way to order a string as used in `getRacesAsLocationPairs`
-  private static String causalPairToOrderedString(
-      CausalPair<? extends Event, ? extends Event> pair) {
-    String fst =
-        pair.getFirst() != null
-            ? pair.getFirst().toString() + ":" + pair.getFirst().getLineOfCode()
-            : " ";
-    String snd =
-        pair.getSecond() != null
-            ? pair.getSecond().toString() + ":" + pair.getSecond().getLineOfCode()
-            : " ";
-    if (fst.compareTo(snd) < 0) {
-      return "(" + snd + ", " + fst + ")";
-    }
-    return "(" + fst + ", " + snd + ")";
-  }
+    private HashSet<CausalPair<? extends Event, ? extends Event>> msgRaceCandidates;
 
-  public void generateConstraintModel() throws IOException {
-    long modelStart = System.currentTimeMillis();
-    genIntraNodeConstraints();
-    genInterNodeConstraints();
-    double buildingModelTime = System.currentTimeMillis() - modelStart;
-    logger.info(
-        "Time to generate constraint model: " + (buildingModelTime / (double) 1000) + " seconds");
-  }
+    // HB model, used to encode message arrival constraints
+    private HashMap<SocketEvent, Event> rcvNextEvent;
 
-  public void checkConflicts() throws IOException {
-    genDataRaceCandidates();
-    genMsgRaceCandidates();
-    computeActualDataRaces();
-    computeActualMsgRaces();
-  }
+    private Z3SolverParallel solver;
 
-  /**
-   * Computes which of the data race candidates are actually data races. Must run
-   * genDataRaceCandidates() before.
-   */
-  public void computeActualDataRaces() {
-    if (dataRaceCandidates.isEmpty()) {
-      System.out.println(
-          "[MinhaChecker] No data races to check ("
-              + Stats.INSTANCE.totalDataRaceCandidates
-              + " candidates)");
-      return;
+    private TraceProcessor traceProcessor;
+
+    public RaceDetector( Z3SolverParallel solver, TraceProcessor traceProcessor )
+    {
+        dataRaceCandidates = new HashSet<>();
+        msgRaceCandidates = new HashSet<>();
+        rcvNextEvent = new HashMap<>();
+        this.solver = solver;
+        this.traceProcessor = traceProcessor;
     }
 
-    Stats.INSTANCE.totalDataRaceCandidates = dataRaceCandidates.size();
-    Stats.INSTANCE.totalDataRaceCandidateLocations = countDataRaces();
-    System.out.println(
-        "\n[MinhaChecker] Start data race checking ("
-            + Stats.INSTANCE.totalDataRaceCandidates
-            + " candidates)");
+    // TODO: use the same way to order a string as used in `getRacesAsLocationPairs`
+    private static String causalPairToOrderedString(
+                    CausalPair<? extends Event, ? extends Event> pair )
+    {
+        String fst =
+                        pair.getFirst() != null
+                                        ? pair.getFirst().toString() + ":" + pair.getFirst().getLineOfCode()
+                                        : " ";
+        String snd =
+                        pair.getSecond() != null
+                                        ? pair.getSecond().toString() + ":" + pair.getSecond().getLineOfCode()
+                                        : " ";
+        if ( fst.compareTo( snd ) < 0 )
+        {
+            return "(" + snd + ", " + fst + ")";
+        }
+        return "(" + fst + ", " + snd + ")";
+    }
 
-    long checkingStart = System.currentTimeMillis();
-    dataRaceCandidates = solver.checkRacesParallel(dataRaceCandidates);
-    Stats.INSTANCE.checkingTimeDataRace = System.currentTimeMillis() - checkingStart;
-    Stats.INSTANCE.totalDataRacePairs = dataRaceCandidates.size();
-    Stats.INSTANCE.totalDataRacePairLocations = countDataRaces();
+    public void generateConstraintModel()
+                    throws IOException
+    {
+        long modelStart = System.currentTimeMillis();
+        genIntraNodeConstraints();
+        genInterNodeConstraints();
+        double buildingModelTime = System.currentTimeMillis() - modelStart;
+        logger.info(
+                        "Time to generate constraint model: " + ( buildingModelTime / (double) 1000 ) + " seconds" );
+    }
 
-    System.out.println(
-        "\n#Data Race Candidates: "
-            + Stats.INSTANCE.totalDataRaceCandidates
-            + " | #Actual Data Races: "
-            + Stats.INSTANCE.totalDataRacePairs);
-    prettyPrintDataRaces();
-  }
+    public void checkConflicts()
+                    throws IOException
+    {
+        genDataRaceCandidates();
+        genMsgRaceCandidates();
+        computeActualDataRaces();
+        computeActualMsgRaces();
+    }
 
-  /**
-   * Generate all pairs of message race candidates. A pair of RCV operations is a candidate if: a)
-   * both occur at the same node b) are either from different threads of from different message
-   * handlers in the same thread
-   *
-   * @throws IOException
-   */
-  public void genMsgRaceCandidates() throws IOException {
-    List<MessageCausalPair> list = new ArrayList<>(traceProcessor.sndRcvPairs.values());
-    ListIterator<MessageCausalPair> pairIterator_i = list.listIterator(0);
-    ListIterator<MessageCausalPair> pairIterator_j;
-
-    solver.writeComment("SOCKET CHANNEL CONSTRAINTS");
-    while (pairIterator_i.hasNext()) {
-
-      // Notice here that we are assuming that the collected trace
-      // is agnostic of network partitioning. As such, we obtain only the first
-      // element in the RCV events list for a message. This is true for all
-      // the code in this class.
-      SocketEvent rcv1 = pairIterator_i.next().getRcv(0);
-
-      if (rcv1 == null) {
-        continue;
-      }
-
-      // advance iterator to have two different pairs
-      pairIterator_j = list.listIterator(pairIterator_i.nextIndex());
-
-      while (pairIterator_j.hasNext()) {
-        SocketEvent rcv2 = pairIterator_j.next().getRcv(0);
-        if (rcv2 == null) {
-          continue;
+    /**
+     * Computes which of the data race candidates are actually data races. Must run
+     * genDataRaceCandidates() before.
+     */
+    public void computeActualDataRaces()
+    {
+        if ( dataRaceCandidates.isEmpty() )
+        {
+            System.out.println(
+                            "[MinhaChecker] No data races to check ("
+                                            + Stats.INSTANCE.totalDataRaceCandidates
+                                            + " candidates)" );
+            return;
         }
 
-        if (rcv1.conflictsWith(rcv2)) {
-          // make a pair with SND events because
-          // two messages a and b are racing if RCVa || SNDb
-          SocketEvent snd1 = traceProcessor.sndRcvPairs.get(rcv1.getMessageId()).getSnd(0);
-          SocketEvent snd2 = traceProcessor.sndRcvPairs.get(rcv2.getMessageId()).getSnd(0);
-          CausalPair<SocketEvent, SocketEvent> raceCandidate;
+        Stats.INSTANCE.totalDataRaceCandidates = dataRaceCandidates.size();
+        Stats.INSTANCE.totalDataRaceCandidateLocations = countDataRaces();
+        System.out.println(
+                        "\n[MinhaChecker] Start data race checking ("
+                                        + Stats.INSTANCE.totalDataRaceCandidates
+                                        + " candidates)" );
 
-          if (rcv1.getEventId() < rcv2.getEventId()) {
-            raceCandidate = new CausalPair<>(snd2, rcv1);
-          } else {
-            raceCandidate = new CausalPair<>(snd1, rcv2);
-          }
-          msgRaceCandidates.add(raceCandidate);
+        long checkingStart = System.currentTimeMillis();
+        dataRaceCandidates = solver.checkRacesParallel( dataRaceCandidates );
+        Stats.INSTANCE.checkingTimeDataRace = System.currentTimeMillis() - checkingStart;
+        Stats.INSTANCE.totalDataRacePairs = dataRaceCandidates.size();
+        Stats.INSTANCE.totalDataRacePairLocations = countDataRaces();
 
-          // if socket channel is TCP and SNDs are from the same thread,
-          // then add constraint stating that RCV1 happens before SND2
-          if (snd1.getSocketType() == SocketEvent.SocketType.TCP
-              && snd2.getSocketType() == SocketEvent.SocketType.TCP
-              && snd1.getThread().equals(snd2.getThread())) {
+        System.out.println(
+                        "\n#Data Race Candidates: "
+                                        + Stats.INSTANCE.totalDataRaceCandidates
+                                        + " | #Actual Data Races: "
+                                        + Stats.INSTANCE.totalDataRacePairs );
+        prettyPrintDataRaces();
+    }
 
-            String cnst;
-            // check trace order of SND, as the iterator does not traverse the events
-            // according to the program order
-            if (snd1.getEventId() < snd2.getEventId()) {
-              cnst = solver.cLt(rcv1.toString(), snd2.toString());
-            } else {
-              cnst = solver.cLt(rcv2.toString(), snd1.toString());
+    /**
+     * Generate all pairs of message race candidates. A pair of RCV operations is a candidate if: a)
+     * both occur at the same node b) are either from different threads of from different message
+     * handlers in the same thread
+     *
+     * @throws IOException
+     */
+    public void genMsgRaceCandidates()
+                    throws IOException
+    {
+        List<MessageCausalPair> list = new ArrayList<>( traceProcessor.sndRcvPairs.values() );
+        ListIterator<MessageCausalPair> pairIterator_i = list.listIterator( 0 );
+        ListIterator<MessageCausalPair> pairIterator_j;
+
+        solver.writeComment( "SOCKET CHANNEL CONSTRAINTS" );
+        while ( pairIterator_i.hasNext() )
+        {
+
+            // Notice here that we are assuming that the collected trace
+            // is agnostic of network partitioning. As such, we obtain only the first
+            // element in the RCV events list for a message. This is true for all
+            // the code in this class.
+            SocketEvent rcv1 = pairIterator_i.next().getRcv( 0 );
+
+            if ( rcv1 == null )
+            {
+                continue;
             }
-            solver.writeConst(solver.postNamedAssert(cnst, "TCP"));
-          }
-        }
-      }
-    }
-  }
 
-  /**
-   * Computes which of the message race candidates are actually message races. Must run
-   * genMsgRaceCandidates() before.
-   */
-  public void computeActualMsgRaces() {
-    if (msgRaceCandidates.isEmpty()) {
-      System.out.println(
-          "[MinhaChecker] No message races to check ("
-              + Stats.INSTANCE.totalMsgRaceCandidates
-              + " candidates)");
-      return;
-    }
+            // advance iterator to have two different pairs
+            pairIterator_j = list.listIterator( pairIterator_i.nextIndex() );
 
-    Stats.INSTANCE.totalMsgRaceCandidates = msgRaceCandidates.size();
+            while ( pairIterator_j.hasNext() )
+            {
+                SocketEvent rcv2 = pairIterator_j.next().getRcv( 0 );
+                if ( rcv2 == null )
+                {
+                    continue;
+                }
 
-    System.out.println(
-        "\n[MinhaChecker] Start message race checking ("
-            + Stats.INSTANCE.totalMsgRaceCandidates
-            + " candidates)");
+                if ( rcv1.conflictsWith( rcv2 ) )
+                {
+                    // make a pair with SND events because
+                    // two messages a and b are racing if RCVa || SNDb
+                    SocketEvent snd1 = traceProcessor.sndRcvPairs.get( rcv1.getMessageId() ).getSnd( 0 );
+                    SocketEvent snd2 = traceProcessor.sndRcvPairs.get( rcv2.getMessageId() ).getSnd( 0 );
+                    CausalPair<SocketEvent, SocketEvent> raceCandidate;
 
-    long checkingStart = System.currentTimeMillis();
-    msgRaceCandidates = solver.checkRacesParallel(msgRaceCandidates);
-    Stats.INSTANCE.checkingTimeMsgRace = System.currentTimeMillis() - checkingStart;
-    Stats.INSTANCE.totalMsgRacePairs = msgRaceCandidates.size();
+                    if ( rcv1.getEventId() < rcv2.getEventId() )
+                    {
+                        raceCandidate = new CausalPair<>( snd2, rcv1 );
+                    }
+                    else
+                    {
+                        raceCandidate = new CausalPair<>( snd1, rcv2 );
+                    }
+                    msgRaceCandidates.add( raceCandidate );
 
-    // TODO: use the number of locations instead of number of causalPairs
-    System.out.println(
-        "\n#Message Race Candidates: "
-            + Stats.INSTANCE.totalMsgRaceCandidates
-            + " | #Actual Message Races: "
-            + Stats.INSTANCE.totalMsgRacePairs);
-    prettyPrintMessageRaces();
-    computeDataRacesFromMsgRaces();
-  }
+                    // if socket channel is TCP and SNDs are from the same thread,
+                    // then add constraint stating that RCV1 happens before SND2
+                    if ( snd1.getSocketType() == SocketEvent.SocketType.TCP
+                                    && snd2.getSocketType() == SocketEvent.SocketType.TCP
+                                    && snd1.getThread().equals( snd2.getThread() ) )
+                    {
 
-  private void computeDataRacesFromMsgRaces() {
-    Set<String> dataRacesFromMsgs = new HashSet<>();
-    for (CausalPair<? extends Event, ? extends Event> causalPair : msgRaceCandidates) {
-
-      SocketEvent e1 = (SocketEvent) causalPair.getFirst();
-      SocketEvent e2 = (SocketEvent) causalPair.getSecond();
-
-      // e1 and e2 may be either SND or RCV
-      // get the corresponding message handler
-      String msgId1 = e1.getMessageId();
-      String msgId2 = e2.getMessageId();
-      // once again, it is assumed that there is no network partition
-      SocketEvent rcv1 = traceProcessor.sndRcvPairs.get(msgId1).getRcv(0);
-      SocketEvent rcv2 = traceProcessor.sndRcvPairs.get(msgId2).getRcv(0);
-
-      // check if rcv1 and rcv2 occur at the same node and short circuit otherwise
-      if (!rcv1.getNodeId().equals(rcv2.getNodeId())) {
-        continue;
-      }
-
-      List<Event> handler1 = traceProcessor.handlerEvents.get(rcv1);
-
-      if (handler1 == null) {
-        continue;
-      }
-
-      // get variables accessed in handler 1
-      // set of read events per variable
-      Map<String, Set<RWEvent>> accessesRead1 = new HashMap<>();
-      // set of write events per variable
-      Map<String, Set<RWEvent>> accessesWrite1 = new HashMap<>();
-
-      for (Event e : handler1) {
-        switch (e.getType()) {
-          case READ:
-            RWEvent readEvent = (RWEvent) e;
-            accessesRead1.computeIfAbsent(readEvent.getVariable(), k -> new HashSet<>())
-                .add(readEvent);
-            break;
-          case WRITE:
-            RWEvent writeEvent = (RWEvent) e;
-            accessesWrite1.computeIfAbsent(writeEvent.getVariable(), k -> new HashSet<>())
-                .add(writeEvent);
-            break;
-          default:
-            break;
-        }
-      }
-
-      // Do the same for message 2
-      List<Event> handler2 = traceProcessor.handlerEvents.get(rcv2);
-
-      if (handler2 == null) {
-        continue;
-      }
-
-      // get variables accessed in handler 2
-      // set of read events per variable
-      Map<String, Set<RWEvent>> accessesRead2 = new HashMap<>();
-      // set of write events per variable
-      Map<String, Set<RWEvent>> accessesWrite2 = new HashMap<>();
-      for (Event e : handler2) {
-        switch (e.getType()) {
-          case READ:
-            RWEvent readEvent = (RWEvent) e;
-            accessesRead2.computeIfAbsent(readEvent.getVariable(), k -> new HashSet<>())
-                .add(readEvent);
-            break;
-          case WRITE:
-            RWEvent writeEvent = (RWEvent) e;
-            accessesWrite2.computeIfAbsent(writeEvent.getVariable(), k -> new HashSet<>())
-                .add(writeEvent);
-            break;
-          default:
-            break;
-        }
-      }
-
-      // obtain sets of all variables accessed
-      Set<String> accessedVars = new HashSet<>();
-      accessedVars.addAll(accessesRead1.keySet());
-      accessedVars.addAll(accessesWrite1.keySet());
-      accessedVars.addAll(accessesRead2.keySet());
-      accessedVars.addAll(accessesWrite2.keySet());
-
-      // for all variables accessed:
-      for (String var : accessedVars) {
-        // 1. for all write accesses to a variable, they collide with every write and read access
-        for (RWEvent event1 : accessesWrite1.computeIfAbsent(var, k -> new HashSet<>())) {
-          for (RWEvent event2 : accessesWrite2.computeIfAbsent(var, k -> new HashSet<>())) {
-            CausalPair<RWEvent, RWEvent> dataRace = new CausalPair<>(event1, event2);
-            dataRacesFromMsgs.add(getRaceAsLocationPair(dataRace));
-          }
-        }
-
-        for (RWEvent event1 : accessesWrite1.computeIfAbsent(var, k -> new HashSet<>())) {
-          for (RWEvent event2 : accessesRead2.computeIfAbsent(var, k -> new HashSet<>())) {
-            CausalPair<RWEvent, RWEvent> dataRace = new CausalPair<>(event1, event2);
-            dataRacesFromMsgs.add(getRaceAsLocationPair(dataRace));
-          }
-        }
-
-        // 2. for all read accesses to a variable, they collide with every write access
-        for (RWEvent event1 : accessesRead1.computeIfAbsent(var, k -> new HashSet<>())) {
-          for (RWEvent event2 : accessesWrite2.computeIfAbsent(var, k -> new HashSet<>())) {
-            CausalPair<RWEvent, RWEvent> dataRace = new CausalPair<>(event1, event2);
-            dataRacesFromMsgs.add(getRaceAsLocationPair(dataRace));
-          }
-        }
-      }
-    }
-
-    // print them
-    int i = 0;
-    System.out.println("\n#Data Races from Message Races: " + dataRacesFromMsgs.size());
-    for (String pair : dataRacesFromMsgs) {
-      i++;
-      System.out.println(" > Data Race #" + i + " : " + pair);
-    }
-
-    // update Stats data structure
-    //Stats.INSTANCE.dataRacesFromMsgs = ...
-  }
-
-  private void prettyPrintDataRaces() {
-    long i = 0;
-    Set<String> pairsOfLocations = getRacesAsLocationPairs(dataRaceCandidates);
-
-    for (String pair : pairsOfLocations) {
-      i++;
-      System.out.println(" > Data Race #" + i + " : " + pair);
-    }
-  }
-
-  private void prettyPrintMessageRaces() {
-    int i = 1;
-    for (CausalPair<? extends Event, ? extends Event> conf : msgRaceCandidates) {
-      // translate SND events to their respective RCV events
-      SocketEvent snd1 = (SocketEvent) conf.getFirst();
-      SocketEvent snd2 = (SocketEvent) conf.getSecond();
-      SocketEvent rcv1 = traceProcessor.sndRcvPairs.get(snd1.getMessageId()).getRcv(0);
-      SocketEvent rcv2 = traceProcessor.sndRcvPairs.get(snd2.getMessageId()).getRcv(0);
-      CausalPair<SocketEvent, SocketEvent> rcv_conf = new CausalPair<>(rcv1, rcv2);
-      System.out.println(
-          " > Message-Message Race #" + i++ + " : " + causalPairToOrderedString(rcv_conf));
-
-      // compute read-write sets for each message handler
-      if (!traceProcessor.handlerEvents.containsKey(rcv1)
-          || !traceProcessor.handlerEvents.containsKey(rcv2)) {
-        // System.out.println("\t-- No conflicts");
-      } else {
-        HashSet<RWEvent> readWriteSet1 = new HashSet<>();
-        HashSet<RWEvent> readWriteSet2 = new HashSet<>();
-
-        for (Event e : traceProcessor.handlerEvents.get(rcv1)) {
-          if (e.getType() == EventType.READ || e.getType() == EventType.WRITE) {
-            readWriteSet1.add((RWEvent) e);
-          }
-        }
-
-        for (Event e : traceProcessor.handlerEvents.get(rcv2)) {
-          if (e.getType() == EventType.READ || e.getType() == EventType.WRITE) {
-            readWriteSet2.add((RWEvent) e);
-          }
-        }
-
-        // check for conflicts
-        for (RWEvent e1 : readWriteSet1) {
-          for (RWEvent e2 : readWriteSet2) {
-            if (conflictingEvents(e1, e2)) {
-              CausalPair<RWEvent, RWEvent> race = new CausalPair<>(e1, e2);
-              // System.out.println("\t-- conflict " + causalPairToOrderedString(race));
+                        String cnst;
+                        // check trace order of SND, as the iterator does not traverse the events
+                        // according to the program order
+                        if ( snd1.getEventId() < snd2.getEventId() )
+                        {
+                            cnst = solver.cLt( rcv1.toString(), snd2.toString() );
+                        }
+                        else
+                        {
+                            cnst = solver.cLt( rcv2.toString(), snd1.toString() );
+                        }
+                        solver.writeConst( solver.postNamedAssert( cnst, "TCP" ) );
+                    }
+                }
             }
-          }
         }
-      }
     }
-  }
 
-  /**
-   * Determines whether two memory accesses are conflicting.
-   * This functionality used to be provided by method `conflictsWith` of
-   * Falcon's `RWEvent` class but it was producing wrong results due to its
-   * use of the field `eventId` which is of no use in Spider
-   */
-  private boolean conflictingEvents(RWEvent e1, RWEvent e2) {
-    return (e1.getType() == EventType.WRITE || e2.getType() == EventType.WRITE) && e1.getNodeId()
-        .equals(e2.getNodeId()) && e1.getVariable().equals(e2.getVariable()) &&
-        !e1.getThread().equals(e2.getThread());
-  }
-
-  /**
-   * Generate all pairs of data race candidates. A pair of RW operations is a candidate if: a) at
-   * least of one of the operations is a write b) both operations access the same variable c)
-   * operations are from different threads, but from the same node.
-   */
-  public void genDataRaceCandidates() {
-    for (String var : traceProcessor.writeEvents.keySet()) {
-      for (RWEvent w1 : traceProcessor.writeEvents.get(var)) {
-        // pair with all other writes
-        for (RWEvent w2 : traceProcessor.writeEvents.get(var)) {
-          if (conflictingEvents(w1, w2)) {
-            CausalPair<RWEvent, RWEvent> tmpPair = new CausalPair<>(w1, w2);
-            dataRaceCandidates.add(tmpPair);
-          }
+    /**
+     * Computes which of the message race candidates are actually message races. Must run
+     * genMsgRaceCandidates() before.
+     */
+    public void computeActualMsgRaces()
+    {
+        if ( msgRaceCandidates.isEmpty() )
+        {
+            System.out.println(
+                            "[MinhaChecker] No message races to check ("
+                                            + Stats.INSTANCE.totalMsgRaceCandidates
+                                            + " candidates)" );
+            return;
         }
 
-        // pair with all other reads
-        if (traceProcessor.readEvents.containsKey(var)) {
-          for (RWEvent r2 : traceProcessor.readEvents.get(var)) {
-            CausalPair<RWEvent, RWEvent> tmpPair = new CausalPair<>(w1, r2);
-            if (conflictingEvents(w1, r2)) {
-              dataRaceCandidates.add(tmpPair);
+        Stats.INSTANCE.totalMsgRaceCandidates = msgRaceCandidates.size();
+
+        System.out.println(
+                        "\n[MinhaChecker] Start message race checking ("
+                                        + Stats.INSTANCE.totalMsgRaceCandidates
+                                        + " candidates)" );
+
+        long checkingStart = System.currentTimeMillis();
+        msgRaceCandidates = solver.checkRacesParallel( msgRaceCandidates );
+        Stats.INSTANCE.checkingTimeMsgRace = System.currentTimeMillis() - checkingStart;
+        Stats.INSTANCE.totalMsgRacePairs = msgRaceCandidates.size();
+
+        // TODO: use the number of locations instead of number of causalPairs
+        System.out.println(
+                        "\n#Message Race Candidates: "
+                                        + Stats.INSTANCE.totalMsgRaceCandidates
+                                        + " | #Actual Message Races: "
+                                        + Stats.INSTANCE.totalMsgRacePairs );
+        prettyPrintMessageRaces();
+        computeDataRacesFromMsgRaces();
+    }
+
+    private void computeDataRacesFromMsgRaces()
+    {
+        Set<String> dataRacesFromMsgs = new HashSet<>();
+        for ( CausalPair<? extends Event, ? extends Event> causalPair : msgRaceCandidates )
+        {
+
+            SocketEvent e1 = (SocketEvent) causalPair.getFirst();
+            SocketEvent e2 = (SocketEvent) causalPair.getSecond();
+
+            // e1 and e2 may be either SND or RCV
+            // get the corresponding message handler
+            String msgId1 = e1.getMessageId();
+            String msgId2 = e2.getMessageId();
+            // once again, it is assumed that there is no network partition
+            SocketEvent rcv1 = traceProcessor.sndRcvPairs.get( msgId1 ).getRcv( 0 );
+            SocketEvent rcv2 = traceProcessor.sndRcvPairs.get( msgId2 ).getRcv( 0 );
+
+            // check if rcv1 and rcv2 occur at the same node and short circuit otherwise
+            if ( !rcv1.getNodeId().equals( rcv2.getNodeId() ) )
+            {
+                continue;
             }
-          }
+
+            List<Event> handler1 = traceProcessor.handlerEvents.get( rcv1 );
+
+            if ( handler1 == null )
+            {
+                continue;
+            }
+
+            // get variables accessed in handler 1
+            // set of read events per variable
+            Map<String, Set<RWEvent>> accessesRead1 = new HashMap<>();
+            // set of write events per variable
+            Map<String, Set<RWEvent>> accessesWrite1 = new HashMap<>();
+
+            for ( Event e : handler1 )
+            {
+                switch ( e.getType() )
+                {
+                    case READ:
+                        RWEvent readEvent = (RWEvent) e;
+                        accessesRead1.computeIfAbsent( readEvent.getVariable(), k -> new HashSet<>() )
+                                     .add( readEvent );
+                        break;
+                    case WRITE:
+                        RWEvent writeEvent = (RWEvent) e;
+                        accessesWrite1.computeIfAbsent( writeEvent.getVariable(), k -> new HashSet<>() )
+                                      .add( writeEvent );
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            // Do the same for message 2
+            List<Event> handler2 = traceProcessor.handlerEvents.get( rcv2 );
+
+            if ( handler2 == null )
+            {
+                continue;
+            }
+
+            // get variables accessed in handler 2
+            // set of read events per variable
+            Map<String, Set<RWEvent>> accessesRead2 = new HashMap<>();
+            // set of write events per variable
+            Map<String, Set<RWEvent>> accessesWrite2 = new HashMap<>();
+            for ( Event e : handler2 )
+            {
+                switch ( e.getType() )
+                {
+                    case READ:
+                        RWEvent readEvent = (RWEvent) e;
+                        accessesRead2.computeIfAbsent( readEvent.getVariable(), k -> new HashSet<>() )
+                                     .add( readEvent );
+                        break;
+                    case WRITE:
+                        RWEvent writeEvent = (RWEvent) e;
+                        accessesWrite2.computeIfAbsent( writeEvent.getVariable(), k -> new HashSet<>() )
+                                      .add( writeEvent );
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            // obtain sets of all variables accessed
+            Set<String> accessedVars = new HashSet<>();
+            accessedVars.addAll( accessesRead1.keySet() );
+            accessedVars.addAll( accessesWrite1.keySet() );
+            accessedVars.addAll( accessesRead2.keySet() );
+            accessedVars.addAll( accessesWrite2.keySet() );
+
+            // for all variables accessed:
+            for ( String var : accessedVars )
+            {
+                // 1. for all write accesses to a variable, they collide with every write and read access
+                for ( RWEvent event1 : accessesWrite1.computeIfAbsent( var, k -> new HashSet<>() ) )
+                {
+                    for ( RWEvent event2 : accessesWrite2.computeIfAbsent( var, k -> new HashSet<>() ) )
+                    {
+                        CausalPair<RWEvent, RWEvent> dataRace = new CausalPair<>( event1, event2 );
+                        dataRacesFromMsgs.add( getRaceAsLocationPair( dataRace ) );
+                    }
+                }
+
+                for ( RWEvent event1 : accessesWrite1.computeIfAbsent( var, k -> new HashSet<>() ) )
+                {
+                    for ( RWEvent event2 : accessesRead2.computeIfAbsent( var, k -> new HashSet<>() ) )
+                    {
+                        CausalPair<RWEvent, RWEvent> dataRace = new CausalPair<>( event1, event2 );
+                        dataRacesFromMsgs.add( getRaceAsLocationPair( dataRace ) );
+                    }
+                }
+
+                // 2. for all read accesses to a variable, they collide with every write access
+                for ( RWEvent event1 : accessesRead1.computeIfAbsent( var, k -> new HashSet<>() ) )
+                {
+                    for ( RWEvent event2 : accessesWrite2.computeIfAbsent( var, k -> new HashSet<>() ) )
+                    {
+                        CausalPair<RWEvent, RWEvent> dataRace = new CausalPair<>( event1, event2 );
+                        dataRacesFromMsgs.add( getRaceAsLocationPair( dataRace ) );
+                    }
+                }
+            }
         }
-      }
-    }
-  }
 
-  private void genIntraNodeConstraints() throws IOException {
-    genProgramOrderConstraints();
-    genForkStartConstraints();
-    genJoinExitConstraints();
-    genWaitNotifyConstraints();
-    genLockingConstraints();
-  }
-
-  private void genInterNodeConstraints() throws IOException {
-    genSendReceiveConstraints();
-    genMessageHandlingConstraints();
-  }
-
-  /**
-   * Builds the order constraints within a segment and returns the position in the trace in which
-   * the handler ends
-   *
-   * @return
-   */
-  private int genSegmentOrderConstraints(List<Event> events, int segmentStart) throws IOException {
-
-    // constraint representing the HB relation for the thread's segment
-    StringBuilder orderConstraint = new StringBuilder();
-    int segmentIt;
-
-    for (segmentIt = segmentStart; segmentIt < events.size(); segmentIt++) {
-      Event e = events.get(segmentIt);
-
-      // declare variable
-      String var = solver.declareIntVar(e.toString(), "0", "MAX");
-      solver.writeConst(var);
-
-      // append event to the thread's segment
-      orderConstraint.append(" " + e.toString());
-
-      // handle partial order within message handler
-      if (e.getType() == EventType.RCV
-          && segmentIt < (events.size() - 1)
-          && events.get(segmentIt + 1).getType() == EventType.HNDLBEG) {
-        segmentIt = genSegmentOrderConstraints(events, segmentIt + 1);
-
-        // store event next to RCV to later encode the message arrival order
-        if (segmentIt < events.size() - 1) {
-          rcvNextEvent.put((SocketEvent) e, events.get(segmentIt + 1));
+        // print them
+        int i = 0;
+        System.out.println( "\n#Data Races from Message Races: " + dataRacesFromMsgs.size() );
+        for ( String pair : dataRacesFromMsgs )
+        {
+            i++;
+            System.out.println( " > Data Race #" + i + " : " + pair );
         }
-      } else if (e.getType() == EventType.HNDLEND) {
-        break;
-      }
+
+        // update Stats data structure
+        //Stats.INSTANCE.dataRacesFromMsgs = ...
     }
 
-    // write segment's order constraint
-    solver.writeConst(solver.postNamedAssert(solver.cLt(orderConstraint.toString()), "PC"));
+    private void prettyPrintDataRaces()
+    {
+        long i = 0;
+        Set<String> pairsOfLocations = getRacesAsLocationPairs( dataRaceCandidates );
 
-    return segmentIt;
-  }
-
-  /**
-   * Program order constraints encode the order within a thread's local trace. Asynchronous event
-   * handling causes the same thread to have multiple segments (i.e. handlers), which breaks global
-   * happens-before relation
-   *
-   * @throws IOException
-   */
-  private void genProgramOrderConstraints() throws IOException {
-    System.out.println("[MinhaChecker] Generate program order constraints");
-    solver.writeComment("PROGRAM ORDER CONSTRAINTS");
-    int max = 0;
-    for (SortedSet<Event> l : traceProcessor.eventsPerThread.values()) {
-      max += l.size();
+        for ( String pair : pairsOfLocations )
+        {
+            i++;
+            System.out.println( " > Data Race #" + i + " : " + pair );
+        }
     }
-    solver.writeConst(solver.declareIntVar("MAX"));
-    solver.writeConst(solver.postAssert(solver.cEq("MAX", String.valueOf(max))));
 
-    // generate program order variables and constraints
-    for (SortedSet<Event> eventsSortedSet : traceProcessor.eventsPerThread.values()) {
-      // TODO: be sure that the order of the list is the same as the SortedSet
-      List<Event> events = new ArrayList<>(eventsSortedSet);
-      if (events.isEmpty()) {
-        continue;
-      } else if (events.size() == 1) {
-        // if there's only one event, we just need to declare it as there are no program order
-        // constraints
-        String var = solver.declareIntVar(events.get(0).toString(), "0", "MAX");
-        solver.writeConst(var);
-      } else {
-        // generate program constraints for the thread segment
-        genSegmentOrderConstraints(events, 0);
-      }
+    private void prettyPrintMessageRaces()
+    {
+        int i = 1;
+        for ( CausalPair<? extends Event, ? extends Event> conf : msgRaceCandidates )
+        {
+            // translate SND events to their respective RCV events
+            SocketEvent snd1 = (SocketEvent) conf.getFirst();
+            SocketEvent snd2 = (SocketEvent) conf.getSecond();
+            SocketEvent rcv1 = traceProcessor.sndRcvPairs.get( snd1.getMessageId() ).getRcv( 0 );
+            SocketEvent rcv2 = traceProcessor.sndRcvPairs.get( snd2.getMessageId() ).getRcv( 0 );
+            CausalPair<SocketEvent, SocketEvent> rcv_conf = new CausalPair<>( rcv1, rcv2 );
+            System.out.println(
+                            " > Message-Message Race #" + i++ + " : " + causalPairToOrderedString( rcv_conf ) );
 
-      // build program order constraints for the whole thread trace
+            // compute read-write sets for each message handler
+            if ( !traceProcessor.handlerEvents.containsKey( rcv1 )
+                            || !traceProcessor.handlerEvents.containsKey( rcv2 ) )
+            {
+                // System.out.println("\t-- No conflicts");
+            }
+            else
+            {
+                HashSet<RWEvent> readWriteSet1 = new HashSet<>();
+                HashSet<RWEvent> readWriteSet2 = new HashSet<>();
+
+                for ( Event e : traceProcessor.handlerEvents.get( rcv1 ) )
+                {
+                    if ( e.getType() == EventType.READ || e.getType() == EventType.WRITE )
+                    {
+                        readWriteSet1.add( (RWEvent) e );
+                    }
+                }
+
+                for ( Event e : traceProcessor.handlerEvents.get( rcv2 ) )
+                {
+                    if ( e.getType() == EventType.READ || e.getType() == EventType.WRITE )
+                    {
+                        readWriteSet2.add( (RWEvent) e );
+                    }
+                }
+
+                // check for conflicts
+                for ( RWEvent e1 : readWriteSet1 )
+                {
+                    for ( RWEvent e2 : readWriteSet2 )
+                    {
+                        if ( conflictingEvents( e1, e2 ) )
+                        {
+                            CausalPair<RWEvent, RWEvent> race = new CausalPair<>( e1, e2 );
+                            // System.out.println("\t-- conflict " + causalPairToOrderedString(race));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Determines whether two memory accesses are conflicting.
+     * This functionality used to be provided by method `conflictsWith` of
+     * Falcon's `RWEvent` class but it was producing wrong results due to its
+     * use of the field `eventId` which is of no use in Spider
+     */
+    private boolean conflictingEvents( RWEvent e1, RWEvent e2 )
+    {
+        return ( e1.getType() == EventType.WRITE || e2.getType() == EventType.WRITE ) && e1.getNodeId()
+                                                                                           .equals( e2.getNodeId() )
+                        && e1.getVariable().equals( e2.getVariable() ) &&
+                        !e1.getThread().equals( e2.getThread() );
+    }
+
+    /**
+     * Generate all pairs of data race candidates. A pair of RW operations is a candidate if: a) at
+     * least of one of the operations is a write b) both operations access the same variable c)
+     * operations are from different threads, but from the same node.
+     */
+    public void genDataRaceCandidates()
+    {
+        for ( String var : traceProcessor.writeEvents.keySet() )
+        {
+            for ( RWEvent w1 : traceProcessor.writeEvents.get( var ) )
+            {
+                // pair with all other writes
+                for ( RWEvent w2 : traceProcessor.writeEvents.get( var ) )
+                {
+                    if ( conflictingEvents( w1, w2 ) )
+                    {
+                        CausalPair<RWEvent, RWEvent> tmpPair = new CausalPair<>( w1, w2 );
+                        dataRaceCandidates.add( tmpPair );
+                    }
+                }
+
+                // pair with all other reads
+                if ( traceProcessor.readEvents.containsKey( var ) )
+                {
+                    for ( RWEvent r2 : traceProcessor.readEvents.get( var ) )
+                    {
+                        CausalPair<RWEvent, RWEvent> tmpPair = new CausalPair<>( w1, r2 );
+                        if ( conflictingEvents( w1, r2 ) )
+                        {
+                            dataRaceCandidates.add( tmpPair );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void genIntraNodeConstraints()
+                    throws IOException
+    {
+        genProgramOrderConstraints();
+        genForkStartConstraints();
+        genJoinExitConstraints();
+        genWaitNotifyConstraints();
+        genLockingConstraints();
+    }
+
+    private void genInterNodeConstraints()
+                    throws IOException
+    {
+        genSendReceiveConstraints();
+        //genWeakMessageHandlingConstraints();
+        genStrongMessageHandlingConstraints();
+    }
+
+    /**
+     * Builds the order constraints within a segment and returns the position in the trace in which
+     * the handler ends
+     *
+     * @return
+     */
+    private int genSegmentOrderConstraints( List<Event> events, int segmentStart )
+                    throws IOException
+    {
+
+        // constraint representing the HB relation for the thread's segment
+        StringBuilder orderConstraint = new StringBuilder();
+        int segmentIt;
+
+        for ( segmentIt = segmentStart; segmentIt < events.size(); segmentIt++ )
+        {
+            Event e = events.get( segmentIt );
+
+            // declare variable
+            String var = solver.declareIntVar( e.toString(), "0", "MAX" );
+            solver.writeConst( var );
+
+            // append event to the thread's segment
+            orderConstraint.append( " " + e.toString() );
+
+            // handle partial order within message handler
+            if ( e.getType() == EventType.RCV
+                            && segmentIt < ( events.size() - 1 )
+                            && events.get( segmentIt + 1 ).getType() == EventType.HNDLBEG )
+            {
+                segmentIt = genSegmentOrderConstraints( events, segmentIt + 1 );
+
+                // store event next to RCV to later encode the message arrival order
+                if ( segmentIt < events.size() - 1 )
+                {
+                    rcvNextEvent.put( (SocketEvent) e, events.get( segmentIt + 1 ) );
+                }
+            }
+            else if ( e.getType() == EventType.HNDLEND )
+            {
+                break;
+            }
+        }
+
+        // write segment's order constraint
+        solver.writeConst( solver.postNamedAssert( solver.cLt( orderConstraint.toString() ), "PC" ) );
+
+        return segmentIt;
+    }
+
+    /**
+     * Program order constraints encode the order within a thread's local trace. Asynchronous event
+     * handling causes the same thread to have multiple segments (i.e. handlers), which breaks global
+     * happens-before relation
+     *
+     * @throws IOException
+     */
+    private void genProgramOrderConstraints()
+                    throws IOException
+    {
+        System.out.println( "[MinhaChecker] Generate program order constraints" );
+        solver.writeComment( "PROGRAM ORDER CONSTRAINTS" );
+        int max = 0;
+        for ( SortedSet<Event> l : traceProcessor.eventsPerThread.values() )
+        {
+            max += l.size();
+        }
+        solver.writeConst( solver.declareIntVar( "MAX" ) );
+        solver.writeConst( solver.postAssert( solver.cEq( "MAX", String.valueOf( max ) ) ) );
+
+        // generate program order variables and constraints
+        for ( SortedSet<Event> eventsSortedSet : traceProcessor.eventsPerThread.values() )
+        {
+            // TODO: be sure that the order of the list is the same as the SortedSet
+            List<Event> events = new ArrayList<>( eventsSortedSet );
+            if ( events.isEmpty() )
+            {
+                continue;
+            }
+            else if ( events.size() == 1 )
+            {
+                // if there's only one event, we just need to declare it as there are no program order
+                // constraints
+                String var = solver.declareIntVar( events.get( 0 ).toString(), "0", "MAX" );
+                solver.writeConst( var );
+            }
+            else
+            {
+                // generate program constraints for the thread segment
+                genSegmentOrderConstraints( events, 0 );
+            }
+
+            // build program order constraints for the whole thread trace
       /*StringBuilder orderConstraint = new StringBuilder();
       for(Event e : events){
           //declare variable
@@ -537,269 +630,420 @@ class RaceDetector {
           orderConstraint.append(" "+e.toString());
       }
       solver.writeConst(solver.postNamedAssert(solver.cLt(orderConstraint.toString()), "PC")); */
+        }
     }
-  }
 
-  private void genSendReceiveConstraints() throws IOException {
-    System.out.println("[MinhaChecker] Generate communication constraints");
-    solver.writeComment("SEND-RECEIVE CONSTRAINTS");
-    for (MessageCausalPair pair : traceProcessor.sndRcvPairs.values()) {
+    private void genSendReceiveConstraints()
+                    throws IOException
+    {
+        System.out.println( "[MinhaChecker] Generate communication constraints" );
+        solver.writeComment( "SEND-RECEIVE CONSTRAINTS" );
+        for ( MessageCausalPair pair : traceProcessor.sndRcvPairs.values() )
+        {
 
-      if (pair.getSnd(0) == null || pair.getRcv(0) == null) {
-        continue;
-      }
+            if ( pair.getSnd( 0 ) == null || pair.getRcv( 0 ) == null )
+            {
+                continue;
+            }
 
-      SocketEvent rcv = pair.getRcv(0);
-      String cnst;
+            SocketEvent rcv = pair.getRcv( 0 );
+            String cnst;
 
-      // if there is a message handler, order SND with HANDLERBEGIN instead of RCV
-      if (!traceProcessor.handlerEvents.containsKey(rcv)) {
-        cnst = solver.cLt(pair.getSnd(0).toString(), pair.getRcv(0).toString());
-      } else {
-        Event handlerbegin = traceProcessor.handlerEvents.get(rcv).get(0);
-        cnst = solver.cLt(pair.getSnd(0).toString(), handlerbegin.toString());
-      }
+            // if there is a message handler, order SND with HANDLERBEGIN instead of RCV
+            if ( !traceProcessor.handlerEvents.containsKey( rcv ) )
+            {
+                cnst = solver.cLt( pair.getSnd( 0 ).toString(), pair.getRcv( 0 ).toString() );
+            }
+            else
+            {
+                Event handlerbegin = traceProcessor.handlerEvents.get( rcv ).get( 0 );
+                cnst = solver.cLt( pair.getSnd( 0 ).toString(), handlerbegin.toString() );
+            }
 
-      solver.writeConst(solver.postNamedAssert(cnst, "COM"));
+            solver.writeConst( solver.postNamedAssert( cnst, "COM" ) );
+        }
     }
-  }
 
-  /**
-   * Message Handling constraints encode: - message handler mutual exclusion - message arrival
-   * order
-   *
-   * @throws IOException
-   */
-  private void genMessageHandlingConstraints() throws IOException {
-    System.out.println("[MinhaChecker] Generate message handling constraints");
-    solver.writeComment("MESSAGE HANDLING CONSTRAINTS");
-    String TAG = "HND";
+    /**
+     * Message Handling constraints encode: - message handler mutual exclusion - message arrival
+     * order
+     *
+     * @throws IOException
+     */
+    private void genWeakMessageHandlingConstraints()
+                    throws IOException
+    {
+        System.out.println( "[MinhaChecker] Generate message handling constraints" );
+        solver.writeComment( "MESSAGE HANDLING CONSTRAINTS" );
+        String TAG = "HND";
 
-    HashMap<String, HashSet<SocketEvent>> rcvPerThread = new HashMap<>();
+        HashMap<String, HashSet<SocketEvent>> rcvPerThread = new HashMap<>();
 
     /* encode mutual exclusion constraints, which state that two message handlers in the same thread
     must occur one before the other in any order */
-    for (SocketEvent rcv_i : traceProcessor.handlerEvents.keySet()) {
-      // store all rcv events per thread-socket
-      String key = rcv_i.getThread() + "-" + rcv_i.getDstPort();
-      if (!rcvPerThread.containsKey(key)) {
-        rcvPerThread.put(key, new HashSet<>());
-      }
-      rcvPerThread.get(key).add(rcv_i);
+        for ( SocketEvent rcv_i : traceProcessor.handlerEvents.keySet() )
+        {
+            // store all rcv events per thread-socket
+            String key = rcv_i.getThread() + "-" + rcv_i.getDstPort();
+            if ( !rcvPerThread.containsKey( key ) )
+            {
+                rcvPerThread.put( key, new HashSet<>() );
+            }
+            rcvPerThread.get( key ).add( rcv_i );
 
-      for (SocketEvent rcv_j : traceProcessor.handlerEvents.keySet()) {
-        if (rcv_i != rcv_j
-            && rcv_i.getThread().equals(rcv_j.getThread())
-            && rcv_i.getDstPort() == rcv_j.getDstPort()) {
+            for ( SocketEvent rcv_j : traceProcessor.handlerEvents.keySet() )
+            {
+                if ( rcv_i != rcv_j
+                                && rcv_i.getThread().equals( rcv_j.getThread() )
+                                && rcv_i.getDstPort() == rcv_j.getDstPort() )
+                {
 
-          // mutual exclusion: HENDi < HBEGj V HENDj < HBEGi
-          String handlerBegin_i = traceProcessor.handlerEvents.get(rcv_i).get(0).toString();
-          String handlerEnd_i =
-              traceProcessor
-                  .handlerEvents
-                  .get(rcv_i)
-                  .get(traceProcessor.handlerEvents.get(rcv_i).size() - 1)
-                  .toString();
-          String handlerBegin_j = traceProcessor.handlerEvents.get(rcv_j).get(0).toString();
-          String handlerEnd_j =
-              traceProcessor
-                  .handlerEvents
-                  .get(rcv_j)
-                  .get(traceProcessor.handlerEvents.get(rcv_j).size() - 1)
-                  .toString();
+                    // mutual exclusion: HENDi < HBEGj V HENDj < HBEGi
+                    String handlerBegin_i = traceProcessor.handlerEvents.get( rcv_i ).get( 0 ).toString();
+                    String handlerEnd_i =
+                                    traceProcessor
+                                                    .handlerEvents
+                                                    .get( rcv_i )
+                                                    .get( traceProcessor.handlerEvents.get( rcv_i ).size() - 1 )
+                                                    .toString();
+                    String handlerBegin_j = traceProcessor.handlerEvents.get( rcv_j ).get( 0 ).toString();
+                    String handlerEnd_j =
+                                    traceProcessor
+                                                    .handlerEvents
+                                                    .get( rcv_j )
+                                                    .get( traceProcessor.handlerEvents.get( rcv_j ).size() - 1 )
+                                                    .toString();
 
-          String mutexConst =
-              solver.cOr(
-                  solver.cLt(handlerEnd_i, handlerBegin_j),
-                  solver.cLt(handlerEnd_j, handlerBegin_i));
-          solver.writeConst(solver.postNamedAssert(mutexConst, TAG));
+                    String mutexConst =
+                                    solver.cOr(
+                                                    solver.cLt( handlerEnd_i, handlerBegin_j ),
+                                                    solver.cLt( handlerEnd_j, handlerBegin_i ) );
+                    solver.writeConst( solver.postNamedAssert( mutexConst, TAG ) );
+                }
+            }
         }
-      }
+
+        /* encode possible message arrival order constraints, which state that each RCV event may be
+         * "matched with" any message on the same socket */
+        for ( HashSet<SocketEvent> rcvSet : rcvPerThread.values() )
+        {
+            // for all RCVi in rcvSet :
+            // (RCVi < HNDBegin_i && HNDEnd_i < nextEvent) V (RCVi < HNDBegin_j && HNDEnd_j < nextEvent),
+            // for all j != i
+            for ( SocketEvent rcv_i : rcvSet )
+            {
+                Event nextEvent = rcvNextEvent.get( rcv_i );
+
+                // if the RCV is the last event, then nextEvent == null
+                if ( nextEvent == null )
+                {
+                    continue;
+                }
+
+                StringBuilder outerOr = new StringBuilder();
+                for ( SocketEvent rcv_j : rcvSet )
+                {
+                    String handlerBegin_j = traceProcessor.handlerEvents.get( rcv_j ).get( 0 ).toString();
+                    String handlerEnd_j =
+                                    traceProcessor
+                                                    .handlerEvents
+                                                    .get( rcv_j )
+                                                    .get( traceProcessor.handlerEvents.get( rcv_j ).size() - 1 )
+                                                    .toString();
+                    String innerAnd =
+                                    solver.cLt(
+                                                    rcv_i.toString()
+                                                                    + " "
+                                                                    + handlerBegin_j
+                                                                    + " "
+                                                                    + handlerEnd_j
+                                                                    + " "
+                                                                    + nextEvent.toString() );
+                    outerOr.append( innerAnd + " " );
+                }
+                solver.writeConst( solver.postNamedAssert( solver.cOr( outerOr.toString() ), TAG ) );
+            }
+        }
     }
 
-    /* encode possible message arrival order constraints, which state that each RCV event may be
-     * "matched with" any message on the same socket */
-    for (HashSet<SocketEvent> rcvSet : rcvPerThread.values()) {
-      // for all RCVi in rcvSet :
-      // (RCVi < HNDBegin_i && HNDEnd_i < nextEvent) V (RCVi < HNDBegin_j && HNDEnd_j < nextEvent),
-      // for all j != i
-      for (SocketEvent rcv_i : rcvSet) {
-        Event nextEvent = rcvNextEvent.get(rcv_i);
+    private void genStrongMessageHandlingConstraints()
+                    throws IOException
+    {
+        System.out.println( "[MinhaChecker] Generate message handling constraints" );
+        solver.writeComment( "MESSAGE HANDLING CONSTRAINTS" );
+        String TAG = "HND";
 
-        // if the RCV is the last event, then nextEvent == null
-        if (nextEvent == null) {
-          continue;
+        Map<String, Set<SocketEvent>> rcvPerThread =
+                        new HashMap<>();                // map: thread-socket -> list of rcv events
+        Map<String, Set<Pair<String, String>>> handlersPerThread =
+                        new HashMap<>();  // map: thread-socket -> list of pairs (h_begin, h_end)
+        for ( SocketEvent rcv : traceProcessor.handlerEvents.keySet() )
+        {
+            String key = rcv.getThread() + "-" + rcv.getDstPort();
+            rcvPerThread.putIfAbsent( key, new HashSet<>() );
+            handlersPerThread.putIfAbsent( key, new HashSet<>() );
+
+            // store all rcv events per thread-socket
+            rcvPerThread.get( key ).add( rcv );
+
+            // store all handler pairs per thread-socket
+            List<Event> rcvHandler = traceProcessor.handlerEvents.get( rcv );
+            Pair<String, String> handlerDelimiters = new Pair<>(
+                            rcvHandler.get( 0 ).toString(),
+                            rcvHandler.get( rcvHandler.size() - 1 ).toString() );
+            handlersPerThread.get( key ).add( handlerDelimiters );
         }
 
+        // for each rcv, add assert with disjunction of rcv-handler linkages
+        for ( String threadSocket : rcvPerThread.keySet() )
+        {
+
+            Set<SocketEvent> rcvSet = rcvPerThread.get( threadSocket );
+            Set<Pair<String, String>> handlerSet = handlersPerThread.get( threadSocket );
+            for ( SocketEvent rcv : rcvSet )
+            {
+                String rcvHandlerConstraints =
+                                genRcvHandlerLinkageConstraints( rcv, rcvNextEvent.get( rcv ), handlerSet );
+                solver.writeConst( solver.postNamedAssert( rcvHandlerConstraints, TAG ) );
+            }
+        }
+    }
+
+    /**
+     * Receive Handler linkage constraints encode the mapping between a given Rcv event
+     * and all handlers whose messages arrive at the same thread of R and through the same socket.
+     *
+     * Let R be a Rcv event and H the set of handlers belonging to the same thread of R and the same socket.
+     * The receive-handler linkage constraints state that for all h_i \in H:
+     *    R = hBegin_i
+     *      && hEnd_i < {event next to R in the thread timeline}
+     *      && ( for all {h_j \in H, h_j != h_i}: hEnd_i < hBegin_j || hEnd_j < hBegin_i )
+     *
+     * Briefly speaking, the constraints state that R has to be mapped to one and only one handler.
+     * In particular, if R is mapped to h_i, then all other h_j occur either before or after h_i.
+     *
+     * @throws IOException
+     */
+    private String genRcvHandlerLinkageConstraints( SocketEvent rcv, Event nextEvent,
+                                                    Set<Pair<String, String>> handlers )
+    {
         StringBuilder outerOr = new StringBuilder();
-        for (SocketEvent rcv_j : rcvSet) {
-          String handlerBegin_j = traceProcessor.handlerEvents.get(rcv_j).get(0).toString();
-          String handlerEnd_j =
-              traceProcessor
-                  .handlerEvents
-                  .get(rcv_j)
-                  .get(traceProcessor.handlerEvents.get(rcv_j).size() - 1)
-                  .toString();
-          String innerAnd =
-              solver.cLt(
-                  rcv_i.toString()
-                      + " "
-                      + handlerBegin_j
-                      + " "
-                      + handlerEnd_j
-                      + " "
-                      + nextEvent.toString());
-          outerOr.append(innerAnd + " ");
+
+        // for all h_i \in H, map R with h_i
+        for ( Pair<String, String> handler_i : handlers )
+        {
+            String handlerBegin_i = handler_i.fst;
+            String handlerEnd_i = handler_i.snd;
+            StringBuilder innerAnd = new StringBuilder();
+
+            // R = hBegin_i
+            String rcvHndLinkage = solver.cEq( rcv.toString(), handlerBegin_i );
+            if ( nextEvent != null )
+            {
+                // when there's an event following R, we augment the constraint as follows:
+                //   R = hBegin_i && hEnd_i < nextEvent
+                rcvHndLinkage = rcvHndLinkage + " " + solver.cLt( handlerEnd_i, nextEvent.toString() );
+            }
+
+            innerAnd.append( rcvHndLinkage + " " );
+
+            // for all h_j \in H, h_j != h_i: hEnd_i < hBegin_j || hEnd_j < hBegin_i
+            for ( Pair<String, String> handler_j : handlers )
+            {
+                if ( handler_i == handler_j )
+                    continue;
+
+                String handlerBegin_j = handler_j.fst;
+                String handlerEnd_j = handler_j.snd;
+
+                // hEnd_i < hBegin_j || hEnd_j < hBegin_i
+                String mutexConst = solver.cOr( solver.cLt( handlerEnd_i, handlerBegin_j ),
+                                                solver.cLt( handlerEnd_j, handlerBegin_i ) );
+
+                innerAnd.append( mutexConst + " " );
+            }
+
+            outerOr.append( solver.cAnd( innerAnd.toString() ) + " " );
         }
-        solver.writeConst(solver.postNamedAssert(solver.cOr(outerOr.toString()), TAG));
-      }
+
+        return solver.cOr( outerOr.toString() );
     }
-  }
 
-  private void genForkStartConstraints() throws IOException {
-    System.out.println("[MinhaChecker] Generate fork-start constraints");
-    solver.writeComment("FORK-START CONSTRAINTS");
-    for (List<ThreadCreationEvent> l : traceProcessor.forkEvents.values()) {
-      for (ThreadCreationEvent e : l) {
+    private void genForkStartConstraints()
+                    throws IOException
+    {
+        System.out.println( "[MinhaChecker] Generate fork-start constraints" );
+        solver.writeComment( "FORK-START CONSTRAINTS" );
+        for ( List<ThreadCreationEvent> l : traceProcessor.forkEvents.values() )
+        {
+            for ( ThreadCreationEvent e : l )
+            {
 
-        // don't add fork-start constraints for threads that are spawned but don't start
-        if (traceProcessor.eventsPerThread.containsKey(e.getChildThread())) {
-          String cnst = solver.cLt(e.toString(), "START_" + e.getChildThread());
-          solver.writeConst(solver.postNamedAssert(cnst, "FS"));
+                // don't add fork-start constraints for threads that are spawned but don't start
+                if ( traceProcessor.eventsPerThread.containsKey( e.getChildThread() ) )
+                {
+                    String cnst = solver.cLt( e.toString(), "START_" + e.getChildThread() );
+                    solver.writeConst( solver.postNamedAssert( cnst, "FS" ) );
+                }
+            }
         }
-      }
     }
-  }
 
-  private void genJoinExitConstraints() throws IOException {
-    System.out.println("[MinhaChecker] Generate join-end constraints");
-    solver.writeComment("JOIN-END CONSTRAINTS");
-    for (List<ThreadCreationEvent> l : traceProcessor.joinEvents.values()) {
-      for (ThreadCreationEvent e : l) {
-        String cnst = solver.cLt("END_" + e.getChildThread(), e.toString());
-        solver.writeConst(solver.postNamedAssert(cnst, "JE"));
-      }
-    }
-  }
-
-  private void genLockingConstraints() throws IOException {
-    System.out.println("[MinhaChecker] Generate locking constraints");
-    solver.writeComment("LOCKING CONSTRAINTS");
-    for (String var : traceProcessor.lockEvents.keySet()) {
-      // for two lock/unlock pairs on the same locking object,
-      // one pair must be executed either before or after the other
-      ListIterator<CausalPair<SyncEvent, SyncEvent>> pairIterator_i =
-          traceProcessor.lockEvents.get(var).listIterator(0);
-      ListIterator<CausalPair<SyncEvent, SyncEvent>> pairIterator_j;
-
-      while (pairIterator_i.hasNext()) {
-        CausalPair<SyncEvent, SyncEvent> pair_i = pairIterator_i.next();
-        // advance iterator to have two different pairs
-        pairIterator_j =
-            traceProcessor.lockEvents.get(var).listIterator(pairIterator_i.nextIndex());
-
-        while (pairIterator_j.hasNext()) {
-          CausalPair<SyncEvent, SyncEvent> pair_j = pairIterator_j.next();
-
-          // there is no need to add constraints for locking pairs of the same thread
-          // as they are already encoded in the program order constraints
-          if (pair_i.getFirst().getThread().equals(pair_j.getFirst().getThread())) {
-            continue;
-          }
-
-          // Ui < Lj || Uj < Li
-          String cnstUi_Lj =
-              solver.cLt(pair_i.getSecond().toString(), pair_j.getFirst().toString());
-          String cnstUj_Li =
-              solver.cLt(pair_j.getSecond().toString(), pair_i.getFirst().toString());
-          String cnst = solver.cOr(cnstUi_Lj, cnstUj_Li);
-          solver.writeConst(solver.postNamedAssert(cnst, "LC"));
+    private void genJoinExitConstraints()
+                    throws IOException
+    {
+        System.out.println( "[MinhaChecker] Generate join-end constraints" );
+        solver.writeComment( "JOIN-END CONSTRAINTS" );
+        for ( List<ThreadCreationEvent> l : traceProcessor.joinEvents.values() )
+        {
+            for ( ThreadCreationEvent e : l )
+            {
+                String cnst = solver.cLt( "END_" + e.getChildThread(), e.toString() );
+                solver.writeConst( solver.postNamedAssert( cnst, "JE" ) );
+            }
         }
-      }
     }
-  }
 
-  private void genWaitNotifyConstraints() throws IOException {
-    System.out.println("[MinhaChecker] Generate wait-notify constraints");
-    solver.writeComment("WAIT-NOTIFY CONSTRAINTS");
-    // map: notify event -> list of all binary vars corresponding to that
-    // notify
-    HashMap<SyncEvent, List<String>> binaryVars = new HashMap<>();
+    private void genLockingConstraints()
+                    throws IOException
+    {
+        System.out.println( "[MinhaChecker] Generate locking constraints" );
+        solver.writeComment( "LOCKING CONSTRAINTS" );
+        for ( String var : traceProcessor.lockEvents.keySet() )
+        {
+            // for two lock/unlock pairs on the same locking object,
+            // one pair must be executed either before or after the other
+            ListIterator<CausalPair<SyncEvent, SyncEvent>> pairIterator_i =
+                            traceProcessor.lockEvents.get( var ).listIterator( 0 );
+            ListIterator<CausalPair<SyncEvent, SyncEvent>> pairIterator_j;
 
-    // for a given condition, each notify can be mapped to any wait
-    // but a wait can only have a single notify
-    for (String condition : traceProcessor.waitEvents.keySet()) {
-      for (SyncEvent wait : traceProcessor.waitEvents.get(condition)) {
-        StringBuilder globalOr = new StringBuilder();
+            while ( pairIterator_i.hasNext() )
+            {
+                CausalPair<SyncEvent, SyncEvent> pair_i = pairIterator_i.next();
+                // advance iterator to have two different pairs
+                pairIterator_j =
+                                traceProcessor.lockEvents.get( var ).listIterator( pairIterator_i.nextIndex() );
 
-        for (SyncEvent notify : traceProcessor.notifyEvents.get(condition)) {
-          // binary var used to indicate whether the signal operation is mapped to a wait operation
-          // or not
-          String binVar =
-              "B_"
-                  + condition
-                  + "-W_"
-                  + wait.getThread()
-                  + "_"
-                  + wait.getEventId()
-                  + "-N_"
-                  + notify.getThread()
-                  + "_"
-                  + notify.getEventId();
+                while ( pairIterator_j.hasNext() )
+                {
+                    CausalPair<SyncEvent, SyncEvent> pair_j = pairIterator_j.next();
 
-          if (!binaryVars.containsKey(notify)) {
-            binaryVars.put(notify, new ArrayList<>());
-          }
-          binaryVars.get(notify).add(binVar);
+                    // there is no need to add constraints for locking pairs of the same thread
+                    // as they are already encoded in the program order constraints
+                    if ( pair_i.getFirst().getThread().equals( pair_j.getFirst().getThread() ) )
+                    {
+                        continue;
+                    }
 
-          // const: Oa_sg < Oa_wt && b^{a_sg}_{a_wt} = 1
-          globalOr.append(
-              solver.cAnd(solver.cLt(notify.toString(), wait.toString()), solver.cEq(binVar, "1")));
-          solver.writeConst(solver.declareIntVar(binVar, 0, 1));
+                    // Ui < Lj || Uj < Li
+                    String cnstUi_Lj =
+                                    solver.cLt( pair_i.getSecond().toString(), pair_j.getFirst().toString() );
+                    String cnstUj_Li =
+                                    solver.cLt( pair_j.getSecond().toString(), pair_i.getFirst().toString() );
+                    String cnst = solver.cOr( cnstUi_Lj, cnstUj_Li );
+                    solver.writeConst( solver.postNamedAssert( cnst, "LC" ) );
+                }
+            }
         }
-        solver.writeConst(solver.postNamedAssert(solver.cOr(globalOr.toString()), "WN"));
-      }
     }
 
-    // add constraints stating that a given notify can only be mapped to a single wait operation
-    for (SyncEvent notify : binaryVars.keySet()) {
-      // for notifyAll, we don't constrain the number of waits that can be matched with this notify
-      if (notify.getType() == NOTIFYALL) {
-        // const: Sum_{x \in WT} b^{a_sg}_{x} >= 0
-        solver.writeConst(
-            solver.postNamedAssert(
-                solver.cGeq(solver.cSummation(binaryVars.get(notify)), "0"), "WN"));
-      } else {
-        // const: Sum_{x \in WT} b^{a_sg}_{x} <= 1
-        solver.writeConst(
-            solver.postNamedAssert(
-                solver.cLeq(solver.cSummation(binaryVars.get(notify)), "1"), "WN"));
-      }
+    private void genWaitNotifyConstraints()
+                    throws IOException
+    {
+        System.out.println( "[MinhaChecker] Generate wait-notify constraints" );
+        solver.writeComment( "WAIT-NOTIFY CONSTRAINTS" );
+        // map: notify event -> list of all binary vars corresponding to that
+        // notify
+        HashMap<SyncEvent, List<String>> binaryVars = new HashMap<>();
+
+        // for a given condition, each notify can be mapped to any wait
+        // but a wait can only have a single notify
+        for ( String condition : traceProcessor.waitEvents.keySet() )
+        {
+            for ( SyncEvent wait : traceProcessor.waitEvents.get( condition ) )
+            {
+                StringBuilder globalOr = new StringBuilder();
+
+                for ( SyncEvent notify : traceProcessor.notifyEvents.get( condition ) )
+                {
+                    // binary var used to indicate whether the signal operation is mapped to a wait operation
+                    // or not
+                    String binVar =
+                                    "B_"
+                                                    + condition
+                                                    + "-W_"
+                                                    + wait.getThread()
+                                                    + "_"
+                                                    + wait.getEventId()
+                                                    + "-N_"
+                                                    + notify.getThread()
+                                                    + "_"
+                                                    + notify.getEventId();
+
+                    if ( !binaryVars.containsKey( notify ) )
+                    {
+                        binaryVars.put( notify, new ArrayList<>() );
+                    }
+                    binaryVars.get( notify ).add( binVar );
+
+                    // const: Oa_sg < Oa_wt && b^{a_sg}_{a_wt} = 1
+                    globalOr.append(
+                                    solver.cAnd( solver.cLt( notify.toString(), wait.toString() ),
+                                                 solver.cEq( binVar, "1" ) ) );
+                    solver.writeConst( solver.declareIntVar( binVar, 0, 1 ) );
+                }
+                solver.writeConst( solver.postNamedAssert( solver.cOr( globalOr.toString() ), "WN" ) );
+            }
+        }
+
+        // add constraints stating that a given notify can only be mapped to a single wait operation
+        for ( SyncEvent notify : binaryVars.keySet() )
+        {
+            // for notifyAll, we don't constrain the number of waits that can be matched with this notify
+            if ( notify.getType() == NOTIFYALL )
+            {
+                // const: Sum_{x \in WT} b^{a_sg}_{x} >= 0
+                solver.writeConst(
+                                solver.postNamedAssert(
+                                                solver.cGeq( solver.cSummation( binaryVars.get( notify ) ), "0" ),
+                                                "WN" ) );
+            }
+            else
+            {
+                // const: Sum_{x \in WT} b^{a_sg}_{x} <= 1
+                solver.writeConst(
+                                solver.postNamedAssert(
+                                                solver.cLeq( solver.cSummation( binaryVars.get( notify ) ), "1" ),
+                                                "WN" ) );
+            }
+        }
     }
-  }
 
-  /**
-   * Computes the set of pairs of locations that correspond to races from the set of `CausalPair`s
-   *
-   * @param causalPairs
-   * @return
-   */
-  private Set<String> getRacesAsLocationPairs(
-      Set<CausalPair<? extends Event, ? extends Event>> causalPairs) {
-    return causalPairs.stream()
-        .map(this::getRaceAsLocationPair)
-        .collect(Collectors.toSet());
-  }
+    /**
+     * Computes the set of pairs of locations that correspond to races from the set of `CausalPair`s
+     *
+     * @param causalPairs
+     * @return
+     */
+    private Set<String> getRacesAsLocationPairs(
+                    Set<CausalPair<? extends Event, ? extends Event>> causalPairs )
+    {
+        return causalPairs.stream()
+                          .map( this::getRaceAsLocationPair )
+                          .collect( Collectors.toSet() );
+    }
 
-  private String getRaceAsLocationPair(CausalPair<? extends Event, ? extends Event> causalPair) {
-    String[] locations = {
-        causalPair.getFirst().getLineOfCode(), causalPair.getSecond().getLineOfCode()
-    };
-    Arrays.sort(locations);
-    return "(" + locations[0] + ", " + locations[1] + ")";
-  }
+    private String getRaceAsLocationPair( CausalPair<? extends Event, ? extends Event> causalPair )
+    {
+        String[] locations = {
+                        causalPair.getFirst().getLineOfCode(), causalPair.getSecond().getLineOfCode()
+        };
+        Arrays.sort( locations );
+        return "(" + locations[0] + ", " + locations[1] + ")";
+    }
 
-  private long countDataRaces() {
-    return getRacesAsLocationPairs(dataRaceCandidates).size();
-  }
+    private long countDataRaces()
+    {
+        return getRacesAsLocationPairs( dataRaceCandidates ).size();
+    }
 }

--- a/src/main/java/pt/haslab/spider/RedundantEventPruner.java
+++ b/src/main/java/pt/haslab/spider/RedundantEventPruner.java
@@ -1,12 +1,5 @@
 package pt.haslab.spider;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pt.haslab.taz.TraceProcessor;
@@ -21,486 +14,576 @@ import pt.haslab.taz.events.SyncEvent;
 import pt.haslab.taz.events.ThreadCreationEvent;
 import pt.haslab.taz.utils.Utils;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+
 import static pt.haslab.taz.events.EventType.*;
 
-public class RedundantEventPruner {
-  private TraceProcessor traceProcessor;
-  private static final Logger logger = LoggerFactory.getLogger(RedundantEventPruner.class);
+public class RedundantEventPruner
+{
+    private TraceProcessor traceProcessor;
 
-  // Redundancy Elimination structures
-  private Set<Event> redundantEvents;
-  // Map: thread id -> list of he ids of the messages ids and lock ids in the concurrency context
-  private Map<String, Set<String>> concurrencyContexts;
-  // Map: loc id -> concurrency history of location
-  private Map<String, Set<String>> concurrencyHistories;
-  // Map: key -> list of he ids of the messages ids and lock ids in the concurrency history
-  private Map<String, Stack<String>> stacks;
+    private static final Logger logger = LoggerFactory.getLogger( RedundantEventPruner.class );
 
-  public RedundantEventPruner(TraceProcessor traceProcessor) {
-    redundantEvents = new HashSet<>();
-    concurrencyContexts = new HashMap<>();
-    concurrencyHistories = new HashMap<>();
-    stacks = new HashMap<>();
-    this.traceProcessor = traceProcessor;
-  }
+    // Redundancy Elimination structures
+    private Set<Event> redundantEvents;
 
-  /**
-   * Removes redundant events for data race detection. Literal implementation the ReX algorithm
-   * (https://parasol.tamu.edu/~jeff/academic/rex.pdf). Assumes: 1) the order of the event iterator
-   * matches the partial order defined by the HB relation 2) the function getStack in ReX depends
-   * only on the current concurrency context and location (the concurrency history is not important)
-   * This is based on my interpretation of the ReX algorithm, whose presentation in the paper is not
-   * clear. This version of the algorithm is not paralelizable.
-   *
-   * @return the number of removed events
-   */
-  public long removeRedundantRW() {
-    EventIterator events = new EventIterator(traceProcessor.eventsPerThread.values());
-    long count = 0;
-    long rwEvents = 0;
+    // Map: thread id -> list of he ids of the messages ids and lock ids in the concurrency context
+    private Map<String, Set<String>> concurrencyContexts;
 
-    for (String t : traceProcessor.eventsPerThread.keySet()) {
-      concurrencyContexts.put(t, new HashSet<>());
+    // Map: loc id -> concurrency history of location
+    private Map<String, Set<String>> concurrencyHistories;
+
+    // Map: key -> list of he ids of the messages ids and lock ids in the concurrency history
+    private Map<String, Stack<String>> stacks;
+
+    public RedundantEventPruner( TraceProcessor traceProcessor )
+    {
+        redundantEvents = new HashSet<>();
+        concurrencyContexts = new HashMap<>();
+        concurrencyHistories = new HashMap<>();
+        stacks = new HashMap<>();
+        this.traceProcessor = traceProcessor;
     }
 
-    while (events.hasNext()) {
-      Event e = events.next();
-      String thread = e.getThread();
-      EventType type = e.getType();
+    /**
+     * Removes redundant events for data race detection. Literal implementation the ReX algorithm
+     * (https://parasol.tamu.edu/~jeff/academic/rex.pdf). Assumes: 1) the order of the event iterator
+     * matches the partial order defined by the HB relation 2) the function getStack in ReX depends
+     * only on the current concurrency context and location (the concurrency history is not important)
+     * This is based on my interpretation of the ReX algorithm, whose presentation in the paper is not
+     * clear. This version of the algorithm is not paralelizable.
+     *
+     * @return the number of removed events
+     */
+    public long removeRedundantRW()
+    {
+        EventIterator events = new EventIterator( traceProcessor.eventsPerThread.values() );
+        long count = 0;
+        long rwEvents = 0;
 
-      if (type == null) {
-        throw new RuntimeException("EventType not known");
-      }
+        for ( String t : traceProcessor.eventsPerThread.keySet() )
+        {
+            concurrencyContexts.put( t, new HashSet<>() );
+        }
 
-      switch (type) {
-        case LOCK:
-          break;
-        case UNLOCK:
-          SyncEvent ue = (SyncEvent) e;
-          Utils.insertInMapToSets(concurrencyContexts, thread, ue.getVariable());
-          break;
-        case READ:
-        case WRITE:
-          // MEM Access
-          RWEvent rwe = (RWEvent) e;
-          if (checkRedundancyRW(rwe)) {
-            // if an event is redundant, remove from the trace
-            logger.debug("ReX (Phase 1): Event " + e + " is redundant.");
-            events.remove();
-            redundantEvents.add(e);
-            removeEventMetadata(rwe);
-            count++;
-          }
-          rwEvents++;
-          break;
-        case SND:
-          SocketEvent se = (SocketEvent) e;
-          Utils.insertInMapToSets(concurrencyContexts, thread, se.getSocket() + se.getLineOfCode());
-          break;
-        case CREATE:
-          // handles CREATE events the same way it handles SND because it also introduces
-          // an outgoing HB edge
-          ThreadCreationEvent tse = (ThreadCreationEvent) e;
-          Utils.insertInMapToSets(concurrencyContexts, thread, tse.getChildThread());
-          break;
-        default:
-          // advance e
-          break;
-      }
+        while ( events.hasNext() )
+        {
+            Event e = events.next();
+            String thread = e.getThread();
+            EventType type = e.getType();
+
+            if ( type == null )
+            {
+                throw new RuntimeException( "EventType not known" );
+            }
+
+            switch ( type )
+            {
+                case LOCK:
+                    break;
+                case UNLOCK:
+                    SyncEvent ue = (SyncEvent) e;
+                    Utils.insertInMapToSets( concurrencyContexts, thread, ue.getVariable() );
+                    break;
+                case READ:
+                case WRITE:
+                    // MEM Access
+                    RWEvent rwe = (RWEvent) e;
+                    if ( checkRedundancyRW( rwe ) )
+                    {
+                        // if an event is redundant, remove from the trace
+                        logger.debug( "ReX (Phase 1): Event " + e + " is redundant." );
+                        events.remove();
+                        redundantEvents.add( e );
+                        removeEventMetadata( rwe );
+                        count++;
+                    }
+                    rwEvents++;
+                    break;
+                case SND:
+                    SocketEvent se = (SocketEvent) e;
+                    Utils.insertInMapToSets( concurrencyContexts, thread, se.getSocket() + se.getLineOfCode() );
+                    break;
+                case CREATE:
+                    // handles CREATE events the same way it handles SND because it also introduces
+                    // an outgoing HB edge
+                    ThreadCreationEvent tse = (ThreadCreationEvent) e;
+                    Utils.insertInMapToSets( concurrencyContexts, thread, tse.getChildThread() );
+                    break;
+                default:
+                    // advance e
+                    break;
+            }
+        }
+        Stats.INSTANCE.percentRedundantRW = 100d * ( (double) count ) / rwEvents;
+        return count;
     }
-    Stats.INSTANCE.percentRedundantRW = 100d * ((double) count) / rwEvents;
-    return count;
-  }
 
-  private boolean checkRedundancyRW(RWEvent event) {
-    String thread = event.getThread();
-    Set<String> concurrencyContext = concurrencyContexts.get(thread);
-    Stack<String> stack = getStack(event.getLineOfCode(), concurrencyContext);
+    private boolean checkRedundancyRW( RWEvent event )
+    {
+        String thread = event.getThread();
+        Set<String> concurrencyContext = concurrencyContexts.get( thread );
+        Stack<String> stack = getStack( event.getLineOfCode(), concurrencyContext );
 
-    if (stack.empty()) {
-      stack.push(thread);
-      return false;
-    } else if (stack.contains(thread) || stack.size() == 2) {
-      // if the stack already contains the thread or is full
-      return true;
-    } else if (stack.size() == 1) {
-      // Stack has size 1 and does not contain the thread
-      stack.push(thread);
-      return false;
+        if ( stack.empty() )
+        {
+            stack.push( thread );
+            return false;
+        }
+        else if ( stack.contains( thread ) || stack.size() == 2 )
+        {
+            // if the stack already contains the thread or is full
+            return true;
+        }
+        else if ( stack.size() == 1 )
+        {
+            // Stack has size 1 and does not contain the thread
+            stack.push( thread );
+            return false;
+        }
+        return false;
     }
-    return false;
-  }
 
-  private Stack<String> getStack(String loc, Set<String> concurrencyContext) {
-    Set<String> concurrencyHistory = concurrencyHistories.computeIfAbsent(loc, k -> new HashSet<>());
+    private Stack<String> getStack( String loc, Set<String> concurrencyContext )
+    {
+        Set<String> concurrencyHistory = concurrencyHistories.computeIfAbsent( loc, k -> new HashSet<>() );
 
-    // If a statement can produce more than one event, than this line shoudld change.
-    // The key should be extended with some string which can differentiate between events
-    // produced on the same statement.
-    String key = "loc:" + loc + ":" + concurrencyContext.hashCode();
-    Stack<String> stack = stacks.computeIfAbsent(key, k -> new Stack<>());
+        // If a statement can produce more than one event, than this line shoudld change.
+        // The key should be extended with some string which can differentiate between events
+        // produced on the same statement.
+        String key = "loc:" + loc + ":" + concurrencyContext.hashCode();
+        Stack<String> stack = stacks.computeIfAbsent( key, k -> new Stack<>() );
 
-    return stack;
-  }
+        return stack;
+    }
 
-  public long removeRedundantInterThreadEvents() {
-    return removeRedundantInterThreadEvents(false);
-  }
+    public long removeRedundantInterThreadEvents()
+    {
+        return removeRedundantInterThreadEvents( false );
+    }
 
-  /**
-   * Generalize ReX algorithm to distributed systems, making it capable of pruning SND and RCV
-   * events. For maximum effectiveness, this mehtod should be run after `removeRedundantRW`.
-   *
-   * @return the number of removed events
-   */
-  public long removeRedundantInterThreadEvents(boolean removeMsgsWithoutHandler) {
-    // can be optimized to check only once every part of the code
-    Set<String> checkedThreads = new HashSet<>();
-    Set<Event> redundantInterThreadEvents = new HashSet<>();
+    /**
+     * Generalize ReX algorithm to distributed systems, making it capable of pruning SND and RCV
+     * events. For maximum effectiveness, this mehtod should be run after `removeRedundantRW`.
+     *
+     * @return the number of removed events
+     */
+    public long removeRedundantInterThreadEvents( boolean removeMsgsWithoutHandler )
+    {
+        // can be optimized to check only once every part of the code
+        Set<String> checkedThreads = new HashSet<>();
+        Set<Event> redundantInterThreadEvents = new HashSet<>();
 
-    for (String thread : traceProcessor.eventsPerThread.keySet()) {
-      int i = 0;
-      if (checkedThreads.contains(thread)) {
-        continue;
-      }
+        for ( String thread : traceProcessor.eventsPerThread.keySet() )
+        {
+            int i = 0;
+            if ( checkedThreads.contains( thread ) )
+            {
+                continue;
+            }
 
-      // TODO: be sure that the order of the list is the same as the SortedSet
-      List<Event> events = new ArrayList<>(traceProcessor.eventsPerThread.get(thread));
-      for (Event e : events) {
+            // TODO: be sure that the order of the list is the same as the SortedSet
+            List<Event> events = new ArrayList<>( traceProcessor.eventsPerThread.get( thread ) );
+            for ( Event e : events )
+            {
+                EventType type = e.getType();
+
+                if ( redundantInterThreadEvents.contains( e ) )
+                {
+                    continue;
+                }
+
+                switch ( type )
+                {
+                    case CREATE:
+                        ThreadCreationEvent tce = (ThreadCreationEvent) e;
+                        String child = tce.getChildThread();
+
+                        if ( canRemoveBlock( traceProcessor.eventsPerThread.get( child ) ) )
+                        {
+                            // marks events to remove instead of removing in order to prevent changes in the
+                            // iterated collection
+                            redundantInterThreadEvents.add( tce );
+                            redundantInterThreadEvents.addAll( traceProcessor.eventsPerThread.get( child ) );
+                            checkedThreads.add( child );
+
+                            ThreadCreationEvent join = getCorrespondingJoin( tce );
+                            if ( join != null )
+                            {
+                                redundantInterThreadEvents.add( join );
+                            }
+                        }
+                        break;
+
+                    case RCV:
+                        SocketEvent rcve = (SocketEvent) e;
+                        List<Event> handler = traceProcessor.handlerEvents.get( rcve );
+                        MessageCausalPair pair = traceProcessor.sndRcvPairs.get( rcve.getMessageId() );
+
+                        // if the send/rcv is redundant and there is no message handler
+                        if ( ( ( handler == null && removeMsgsWithoutHandler ) || canRemoveHandler( handler ) )
+                                        && pair != null )
+                        {
+
+                            // I'm assuming that there is no message partition or at least that partitioning
+                            // is abstracted from the trace
+                            List<SocketEvent> sndList = pair.getSndList();
+                            List<SocketEvent> rcvList = pair.getRcvList();
+
+                            if ( sndList != null )
+                            {
+                                redundantInterThreadEvents.addAll( sndList );
+                            }
+
+                            if ( rcvList != null )
+                            {
+                                redundantInterThreadEvents.addAll( rcvList );
+                            }
+
+                            if ( handler != null )
+                            {
+                                redundantInterThreadEvents.addAll( handler );
+                            }
+                        }
+                        break;
+                    case LOCK:
+                        SyncEvent lockEvent = (SyncEvent) e;
+                        SyncEvent unlockEvent = getCorrespondingUnlock( lockEvent );
+
+                        if ( unlockEvent != null )
+                        {
+                            List<Event> subTrace = events.subList( i, events.indexOf( unlockEvent ) + 1 );
+                            if ( canRemoveLockedBlock( subTrace ) )
+                            {
+                                redundantInterThreadEvents.add( e );
+                                redundantInterThreadEvents.add( unlockEvent );
+                            }
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                i++;
+            }
+            checkedThreads.add( thread );
+        }
+
+        for ( Event e : redundantInterThreadEvents )
+        {
+            logger.debug( "ReX (Phase 2): Event " + e + " is redundant." );
+            removeEventMetadata( e );
+            traceProcessor.eventsPerThread.get( e.getThread() ).remove( e );
+        }
+
+        return redundantInterThreadEvents.size();
+    }
+
+    /**
+     * Removes the data associated with this event from the Trace Processor auxiliary structures. Does
+     * NOT remove events from eventsPerThread. This operation is idempotent.
+     */
+    private void removeEventMetadata( Event e )
+    {
+        if ( e == null )
+        {
+            return;
+        }
+
+        String var;
+        EventType type = e.getType();
+        String thread = e.getThread();
+        switch ( type )
+        {
+            case SND:
+            case RCV:
+                removeEventMetadataAux( (SocketEvent) e );
+                break;
+            case CREATE:
+                traceProcessor.forkEvents.get( thread ).remove( e );
+                break;
+            case JOIN:
+                traceProcessor.joinEvents.get( thread ).remove( e );
+                break;
+            case LOCK:
+            case UNLOCK:
+                removeEventMetadataAux( (SyncEvent) e );
+                break;
+            case READ:
+                RWEvent readEvent = (RWEvent) e;
+                var = readEvent.getVariable();
+                removeFromMapToLists( traceProcessor.readEvents, var, readEvent );
+                break;
+            case WRITE:
+                RWEvent writeEvent = (RWEvent) e;
+                var = writeEvent.getVariable();
+                removeFromMapToLists( traceProcessor.writeEvents, var, writeEvent );
+                break;
+            case WAIT:
+                SyncEvent waitEvent = (SyncEvent) e;
+                var = waitEvent.getVariable();
+                removeFromMapToLists( traceProcessor.waitEvents, var, waitEvent );
+                break;
+            case NOTIFY:
+            case NOTIFYALL:
+                SyncEvent notifyEvent = (SyncEvent) e;
+                var = notifyEvent.getVariable();
+                removeFromMapToLists( traceProcessor.notifyEvents, var, notifyEvent );
+                break;
+        }
+
+        for ( List<Event> l : traceProcessor.handlerEvents.values() )
+        {
+            if ( l.remove( e ) )
+            {
+                return;
+            }
+        }
+    }
+
+    /**
+     * This methods is responsible for removing metadata associated with SND and RCV events.
+     *
+     * @param e - the event whose metadata is to be prunned
+     */
+    private void removeEventMetadataAux( SocketEvent e )
+    {
+        // Did not call this method removeEventMetadata to avoid erroneous invocations -> the method
+        // removeEventMetada runs necessary operations for all events. Didn't want to make people
+        // call removeEventMetadataAux by mistake so I named it this way.
+        switch ( e.getType() )
+        {
+            case SND:
+                // removes both SND and RCV from msgEvents
+                String msgId = e.getMessageId();
+                traceProcessor.sndRcvPairs.remove( msgId );
+                break;
+            case RCV:
+                // remove msg handler
+                List<Event> handler = traceProcessor.handlerEvents.remove( e );
+                if ( handler != null )
+                {
+                    for ( Event x : handler )
+                    {
+                        removeEventMetadata( x );
+                    }
+                }
+                break;
+            default:
+                throw new RuntimeException( "Removing event metadata with the wrong method" );
+        }
+    }
+
+    /**
+     * This methods is responsible for removing metadata associated with LOCK and UNLOCK events.
+     *
+     * @param e - the event whose metadata is to be prunned
+     */
+    private void removeEventMetadataAux( SyncEvent e )
+    {
         EventType type = e.getType();
 
-        if (redundantInterThreadEvents.contains(e)) {
-          continue;
+        if ( type != LOCK && type != UNLOCK )
+        {
+            throw new RuntimeException( "Removing event metadata with the wrong method" );
         }
 
-        switch (type) {
-          case CREATE:
-            ThreadCreationEvent tce = (ThreadCreationEvent) e;
-            String child = tce.getChildThread();
-
-            if (canRemoveBlock(traceProcessor.eventsPerThread.get(child))) {
-              // marks events to remove instead of removing in order to prevent changes in the
-              // iterated collection
-              redundantInterThreadEvents.add(tce);
-              redundantInterThreadEvents.addAll(traceProcessor.eventsPerThread.get(child));
-              checkedThreads.add(child);
-
-              ThreadCreationEvent join = getCorrespondingJoin(tce);
-              if (join != null) {
-                redundantInterThreadEvents.add(join);
-              }
+        String var = e.getVariable();
+        List<CausalPair<SyncEvent, SyncEvent>> pairs = traceProcessor.lockEvents.get( var );
+        if ( pairs != null )
+        {
+            CausalPair<SyncEvent, SyncEvent> res = null;
+            for ( CausalPair<SyncEvent, SyncEvent> pair : pairs )
+            {
+                SyncEvent fst = pair.getFirst();
+                SyncEvent snd = pair.getSecond();
+                if ( e.equals( fst ) || e.equals( snd ) )
+                {
+                    res = pair;
+                    break;
+                }
             }
-            break;
 
-          case RCV:
-            SocketEvent rcve = (SocketEvent) e;
-            List<Event> handler = traceProcessor.handlerEvents.get(rcve);
-            MessageCausalPair pair = traceProcessor.sndRcvPairs.get(rcve.getMessageId());
-
-            // if the send/rcv is redundant and there is no message handler
-            if (((handler == null && removeMsgsWithoutHandler) || canRemoveHandler(handler))
-                && pair != null) {
-
-              // I'm assuming that there is no message partition or at least that partitioning
-              // is abstracted from the trace
-              List<SocketEvent> sndList = pair.getSndList();
-              List<SocketEvent> rcvList = pair.getRcvList();
-
-              if (sndList != null) {
-                redundantInterThreadEvents.addAll(sndList);
-              }
-
-              if (rcvList != null) {
-                redundantInterThreadEvents.addAll(rcvList);
-              }
-
-              if (handler != null) {
-                redundantInterThreadEvents.addAll(handler);
-              }
+            if ( res != null )
+            {
+                pairs.remove( res );
             }
-            break;
-          case LOCK:
-            SyncEvent lockEvent = (SyncEvent) e;
-            SyncEvent unlockEvent = getCorrespondingUnlock(lockEvent);
-
-            if (unlockEvent != null) {
-              List<Event> subTrace = events.subList(i, events.indexOf(unlockEvent) + 1);
-              if (canRemoveLockedBlock(subTrace)) {
-                redundantInterThreadEvents.add(e);
-                redundantInterThreadEvents.add(unlockEvent);
-              }
-            }
-            break;
-          default:
-            break;
         }
-        i++;
-      }
-      checkedThreads.add(thread);
     }
 
-    for (Event e : redundantInterThreadEvents) {
-      logger.debug("ReX (Phase 2): Event " + e + " is redundant.");
-      removeEventMetadata(e);
-      traceProcessor.eventsPerThread.get(e.getThread()).remove(e);
-    }
-
-    return redundantInterThreadEvents.size();
-  }
-
-  /**
-   * Removes the data associated with this event from the Trace Processor auxiliary structures. Does
-   * NOT remove events from eventsPerThread. This operation is idempotent.
-   */
-  private void removeEventMetadata(Event e) {
-    if (e == null) {
-      return;
-    }
-
-    String var;
-    EventType type = e.getType();
-    String thread = e.getThread();
-    switch (type) {
-      case SND:
-      case RCV:
-        removeEventMetadataAux((SocketEvent) e);
-        break;
-      case CREATE:
-        traceProcessor.forkEvents.get(thread).remove(e);
-        break;
-      case JOIN:
-        traceProcessor.joinEvents.get(thread).remove(e);
-        break;
-      case LOCK:
-      case UNLOCK:
-        removeEventMetadataAux((SyncEvent) e);
-        break;
-      case READ:
-        RWEvent readEvent = (RWEvent) e;
-        var = readEvent.getVariable();
-        removeFromMapToLists(traceProcessor.readEvents, var, readEvent);
-        break;
-      case WRITE:
-        RWEvent writeEvent = (RWEvent) e;
-        var = writeEvent.getVariable();
-        removeFromMapToLists(traceProcessor.writeEvents, var, writeEvent);
-        break;
-      case WAIT:
-        SyncEvent waitEvent = (SyncEvent) e;
-        var = waitEvent.getVariable();
-        removeFromMapToLists(traceProcessor.waitEvents, var, waitEvent);
-        break;
-      case NOTIFY:
-      case NOTIFYALL:
-        SyncEvent notifyEvent = (SyncEvent) e;
-        var = notifyEvent.getVariable();
-        removeFromMapToLists(traceProcessor.notifyEvents, var, notifyEvent);
-        break;
-    }
-
-    for (List<Event> l : traceProcessor.handlerEvents.values()) {
-      if (l.remove(e)) {
-        return;
-      }
-    }
-  }
-
-  /**
-   * This methods is responsible for removing metadata associated with SND and RCV events.
-   *
-   * @param e - the event whose metadata is to be prunned
-   */
-  private void removeEventMetadataAux(SocketEvent e) {
-    // Did not call this method removeEventMetadata to avoid erroneous invocations -> the method
-    // removeEventMetada runs necessary operations for all events. Didn't want to make people
-    // call removeEventMetadataAux by mistake so I named it this way.
-    switch (e.getType()) {
-      case SND:
-        // removes both SND and RCV from msgEvents
-        String msgId = e.getMessageId();
-        traceProcessor.sndRcvPairs.remove(msgId);
-        break;
-      case RCV:
-        // remove msg handler
-        List<Event> handler = traceProcessor.handlerEvents.remove(e);
-        if (handler != null) {
-          for (Event x : handler) {
-            removeEventMetadata(x);
-          }
-        }
-        break;
-      default:
-        throw new RuntimeException("Removing event metadata with the wrong method");
-    }
-  }
-
-  /**
-   * This methods is responsible for removing metadata associated with LOCK and UNLOCK events.
-   *
-   * @param e - the event whose metadata is to be prunned
-   */
-  private void removeEventMetadataAux(SyncEvent e) {
-    EventType type = e.getType();
-
-    if (type != LOCK && type != UNLOCK) {
-      throw new RuntimeException("Removing event metadata with the wrong method");
-    }
-
-    String var = e.getVariable();
-    List<CausalPair<SyncEvent, SyncEvent>> pairs = traceProcessor.lockEvents.get(var);
-    if (pairs != null) {
-      CausalPair<SyncEvent, SyncEvent> res = null;
-      for (CausalPair<SyncEvent, SyncEvent> pair : pairs) {
-        SyncEvent fst = pair.getFirst();
-        SyncEvent snd = pair.getSecond();
-        if (e.equals(fst) || e.equals(snd)) {
-          res = pair;
-          break;
-        }
-      }
-
-      if (res != null) {
-        pairs.remove(res);
-      }
-    }
-  }
-
-  private boolean canRemoveHandler(List<Event> handler) {
-    Set<String> openLocks = new HashSet<>();
-    if (handler == null) {
-      return false;
-    }
-    for (Event e : handler) {
-      EventType type = e.getType();
-      if (redundantEvents.contains(e)) {
-        continue;
-      }
-      // If a block has any instruction capable of inducing a specific ordering of events,
-      // it cannot be removed
-      switch (type) {
-        case SND:
-        case RCV:
-        case READ:
-        case WRITE:
-        case NOTIFY:
-        case NOTIFYALL:
-        case WAIT:
-        case CREATE:
-          return false;
-        case LOCK:
-          openLocks.add(((SyncEvent) e).getVariable());
-          break;
-        case UNLOCK:
-          if (!openLocks.remove(((SyncEvent) e).getVariable())) {
-            // tried to unlock a thread open outside the handler
+    private boolean canRemoveHandler( List<Event> handler )
+    {
+        Set<String> openLocks = new HashSet<>();
+        if ( handler == null )
+        {
             return false;
-          }
-          break;
-        default:
-          break;
-      }
+        }
+        for ( Event e : handler )
+        {
+            EventType type = e.getType();
+            if ( redundantEvents.contains( e ) )
+            {
+                continue;
+            }
+            // If a block has any instruction capable of inducing a specific ordering of events,
+            // it cannot be removed
+            switch ( type )
+            {
+                case SND:
+                case RCV:
+                case READ:
+                case WRITE:
+                case NOTIFY:
+                case NOTIFYALL:
+                case WAIT:
+                case CREATE:
+                    return false;
+                case LOCK:
+                    openLocks.add( ( (SyncEvent) e ).getVariable() );
+                    break;
+                case UNLOCK:
+                    if ( !openLocks.remove( ( (SyncEvent) e ).getVariable() ) )
+                    {
+                        // tried to unlock a thread open outside the handler
+                        return false;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        return openLocks.isEmpty();
     }
-    return openLocks.isEmpty();
-  }
 
-  private boolean canRemoveBlock(Iterable<Event> events) {
-    for (Event e : events) {
-      EventType type = e.getType();
-      // If a block has any instruction capable of inducing a specific ordering of events,
-      // or capable of creating races, it cannot be removed
-      if (type == SND
-          || type == RCV
-          || type == WRITE
-          || type == READ
-          || type == NOTIFY
-          || type == NOTIFYALL
-          || type == LOCK
-          || type == UNLOCK
-          || type == WAIT) {
+    private boolean canRemoveBlock( Iterable<Event> events )
+    {
+        for ( Event e : events )
+        {
+            EventType type = e.getType();
+            // If a block has any instruction capable of inducing a specific ordering of events,
+            // or capable of creating races, it cannot be removed
+            if ( type == SND
+                            || type == RCV
+                            || type == WRITE
+                            || type == READ
+                            || type == NOTIFY
+                            || type == NOTIFYALL
+                            || type == LOCK
+                            || type == UNLOCK
+                            || type == WAIT )
+            {
+                return false;
+            }
+            else if ( type == CREATE )
+            {
+                // Possible improvement: do the same thing for the SND events
+                ThreadCreationEvent tce = (ThreadCreationEvent) e;
+                if ( !canRemoveBlock( traceProcessor.eventsPerThread.get( tce.getChildThread() ) ) )
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private boolean canRemoveLockedBlock( Iterable<Event> events )
+    {
+        Set<String> openLocks = new HashSet<>();
+        for ( Event e : events )
+        {
+            EventType type = e.getType();
+            // If a block has any instruction capable of inducing a specific ordering of events,
+            // or capable of creating races, it cannot be removed
+            if ( type == SND
+                            || type == RCV
+                            || type == WRITE
+                            || type == READ
+                            || type == NOTIFY
+                            || type == NOTIFYALL
+                            || type == WAIT )
+            {
+                return false;
+            }
+            else if ( type == CREATE )
+            {
+                // Possible improvement: do the same thing for the SND events
+                ThreadCreationEvent tce = (ThreadCreationEvent) e;
+                if ( !canRemoveBlock( traceProcessor.eventsPerThread.get( tce.getChildThread() ) ) )
+                {
+                    return false;
+                }
+            }
+            else if ( type == LOCK )
+            {
+                openLocks.add( ( (SyncEvent) e ).getVariable() );
+            }
+            else if ( type == UNLOCK )
+            {
+                if ( !openLocks.remove( ( (SyncEvent) e ).getVariable() ) )
+                {
+                    // tried to unlock a thread open outside the handler
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static <K, V> boolean removeFromMapToLists( Map<K, List<V>> map, K key, V value )
+    {
+        List<V> l = map.get( key );
+        if ( l != null )
+        {
+            return l.remove( value );
+        }
         return false;
-      } else if (type == CREATE) {
-        // Possible improvement: do the same thing for the SND events
-        ThreadCreationEvent tce = (ThreadCreationEvent) e;
-        if (!canRemoveBlock(traceProcessor.eventsPerThread.get(tce.getChildThread()))) {
-          return false;
+    }
+
+    /**
+     * Returns the UNLOCK event that matches with a given LOCK event.
+     *
+     * @param lockEvent an object representing a particular LOCK event.
+     * @return the UNLOCK event that is causally-related to the LOCK event passed as input.
+     */
+    private SyncEvent getCorrespondingUnlock( SyncEvent lockEvent )
+    {
+        List<CausalPair<SyncEvent, SyncEvent>> pairs =
+                        traceProcessor.lockEvents.get( lockEvent.getVariable() );
+        for ( CausalPair<SyncEvent, SyncEvent> se : pairs )
+        {
+            if ( se.getFirst().equals( lockEvent ) )
+            {
+                return se.getSecond();
+            }
         }
-      }
+        return null;
     }
-    return true;
-  }
 
-  private boolean canRemoveLockedBlock(Iterable<Event> events) {
-    Set<String> openLocks = new HashSet<>();
-    for (Event e : events) {
-      EventType type = e.getType();
-      // If a block has any instruction capable of inducing a specific ordering of events,
-      // or capable of creating races, it cannot be removed
-      if (type == SND
-          || type == RCV
-          || type == WRITE
-          || type == READ
-          || type == NOTIFY
-          || type == NOTIFYALL
-          || type == WAIT) {
-        return false;
-      } else if (type == CREATE) {
-        // Possible improvement: do the same thing for the SND events
-        ThreadCreationEvent tce = (ThreadCreationEvent) e;
-        if (!canRemoveBlock(traceProcessor.eventsPerThread.get(tce.getChildThread()))) {
-          return false;
+    /**
+     * Returns the JOIN event that happens after a given END event.
+     *
+     * @param endEvent an object representing a particular END event.
+     * @return the JOIN event that is causally-related to the END event passed as input.
+     */
+    private ThreadCreationEvent getCorrespondingJoin( ThreadCreationEvent endEvent )
+    {
+        List<ThreadCreationEvent> joins = traceProcessor.joinEvents.get( endEvent.getThread() );
+        String childThread = endEvent.getChildThread();
+        if ( joins == null )
+            return null;
+        for ( ThreadCreationEvent join : joins )
+        {
+            if ( join != null && childThread.equals( join.getChildThread() ) )
+            {
+                return join;
+            }
         }
-      } else if (type == LOCK) {
-        openLocks.add(((SyncEvent) e).getVariable());
-      } else if (type == UNLOCK) {
-        if (!openLocks.remove(((SyncEvent) e).getVariable())) {
-          // tried to unlock a thread open outside the handler
-          return false;
-        }
-      }
+        return null;
     }
-    return true;
-  }
-
-  private static <K, V> boolean removeFromMapToLists(Map<K, List<V>> map, K key, V value) {
-    List<V> l = map.get(key);
-    if (l != null) {
-      return l.remove(value);
-    }
-    return false;
-  }
-
-  /**
-   * Returns the UNLOCK event that matches with a given LOCK event.
-   *
-   * @param lockEvent an object representing a particular LOCK event.
-   * @return the UNLOCK event that is causally-related to the LOCK event passed as input.
-   */
-  private SyncEvent getCorrespondingUnlock(SyncEvent lockEvent) {
-    List<CausalPair<SyncEvent, SyncEvent>> pairs =
-        traceProcessor.lockEvents.get(lockEvent.getVariable());
-    for (CausalPair<SyncEvent, SyncEvent> se : pairs) {
-      if (se.getFirst().equals(lockEvent)) {
-        return se.getSecond();
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Returns the JOIN event that happens after a given END event.
-   *
-   * @param endEvent an object representing a particular END event.
-   * @return the JOIN event that is causally-related to the END event passed as input.
-   */
-  private ThreadCreationEvent getCorrespondingJoin(ThreadCreationEvent endEvent) {
-    List<ThreadCreationEvent> joins = traceProcessor.joinEvents.get(endEvent.getThread());
-    String childThread = endEvent.getChildThread();
-    if (joins == null) return null;
-    for (ThreadCreationEvent join : joins) {
-      if (join != null && childThread.equals(join.getChildThread())) {
-        return join;
-      }
-    }
-    return null;
-  }
 }

--- a/src/main/java/pt/haslab/spider/Stats.java
+++ b/src/main/java/pt/haslab/spider/Stats.java
@@ -2,76 +2,95 @@ package pt.haslab.spider;
 
 import java.text.DecimalFormat;
 
-/** Created by nunomachado on 11/05/17. */
-public enum Stats {
-  INSTANCE;
-  // general variables
-  public long numEventsTrace;
-  public long numConstraints;
-  public long redundantEvents;
-  public long redundantMsgEvents;
-  public double percentRedundantRW;
-  // public static double buildingModelTime = 0;
+/**
+ * Created by nunomachado on 11/05/17.
+ */
+public enum Stats
+{
+    INSTANCE;
 
-  // data race variables
-  public long totalDataRaceCandidates;
-  public long totalDataRacePairs;
-  public double checkingTimeDataRace;
+    // general variables
+    public long numEventsTrace;
 
-  // message race variables
-  public long totalMsgRaceCandidates;
-  public long totalMsgRacePairs;
-  public double checkingTimeMsgRace;
-  public long totalDataRaceCandidateLocations;
-  public long totalDataRacePairLocations;
+    public long numConstraints;
 
-  Stats() {}
+    public long redundantEvents;
 
-  public static Stats getInstance() {
-    return INSTANCE;
-  }
+    public long redundantMsgEvents;
 
-  public String getSummary() {
-    DecimalFormat df = new DecimalFormat("00.00");
-    StringBuilder sb = new StringBuilder();
-    appendLn(sb, "\n=======================");
-    appendLn(sb, "        RESULTS        ");
-    appendLn(sb, "=======================");
-    appendLn(sb, "> Number of events in trace:\t\t" + numEventsTrace);
-    appendLn(sb, "> Number of redundant events in trace:\t\t" + redundantEvents);
-    appendLn(
-        sb,
-        "> Percentage of redundant RW events in trace:\t\t" + df.format(percentRedundantRW) + "%");
-    appendLn(sb, "> Number of redundant inter-thread events in trace:\t\t" + redundantMsgEvents);
-    appendLn(sb, "> Number of constraints in model:\t\t" + numConstraints);
+    public double percentRedundantRW;
+    // public static double buildingModelTime = 0;
+
+    // data race variables
+    public long totalDataRaceCandidates;
+
+    public long totalDataRacePairs;
+
+    public double checkingTimeDataRace;
+
+    // message race variables
+    public long totalMsgRaceCandidates;
+
+    public long totalMsgRacePairs;
+
+    public double checkingTimeMsgRace;
+
+    public long totalDataRaceCandidateLocations;
+
+    public long totalDataRacePairLocations;
+
+    Stats()
+    {
+    }
+
+    public static Stats getInstance()
+    {
+        return INSTANCE;
+    }
+
+    public String getSummary()
+    {
+        DecimalFormat df = new DecimalFormat( "00.00" );
+        StringBuilder sb = new StringBuilder();
+        appendLn( sb, "\n=======================" );
+        appendLn( sb, "        RESULTS        " );
+        appendLn( sb, "=======================" );
+        appendLn( sb, "> Number of events in trace:\t\t" + numEventsTrace );
+        appendLn( sb, "> Number of redundant events in trace:\t\t" + redundantEvents );
+        appendLn(
+                        sb,
+                        "> Percentage of redundant RW events in trace:\t\t" + df.format( percentRedundantRW ) + "%" );
+        appendLn( sb, "> Number of redundant inter-thread events in trace:\t\t" + redundantMsgEvents );
+        appendLn( sb, "> Number of constraints in model:\t\t" + numConstraints );
     /*System.out.println(
     "> Time to generate constraint model:\t\t"
         + (buildingModelTime / (double) 1000)
         + " seconds");*/
-    appendLn(sb, "\n## DATA RACES:");
-    appendLn(sb, "  > Number of data race candidates:\t\t" + totalDataRaceCandidates);
-    appendLn(
-        sb, "  > Number of data race candidate locations:\t\t" + totalDataRaceCandidateLocations);
-    appendLn(sb, "  > Number of actual data races:\t\t" + totalDataRacePairs);
-    appendLn(sb, "  > Number of actual data race locations:\t\t" + totalDataRacePairLocations);
-    appendLn(
-        sb,
-        "  > Time to check all candidates:\t\t"
-            + (checkingTimeDataRace / (double) 1000)
-            + " seconds");
-    appendLn(sb, "\n## MESSAGE RACES:");
-    appendLn(sb, "  > Number of message race candidates:\t\t" + totalMsgRaceCandidates);
-    appendLn(sb, "  > Number of actual message races:\t\t" + totalMsgRacePairs);
-    appendLn(
-        sb,
-        "  > Time to check all message race candidates:\t\t"
-            + (checkingTimeMsgRace / (double) 1000)
-            + " seconds");
-    return sb.toString();
-  }
+        appendLn( sb, "\n## DATA RACES:" );
+        appendLn( sb, "  > Number of data race candidates:\t\t" + totalDataRaceCandidates );
+        appendLn(
+                        sb, "  > Number of data race candidate locations:\t\t" + totalDataRaceCandidateLocations );
+        appendLn( sb, "  > Number of actual data races:\t\t" + totalDataRacePairs );
+        appendLn( sb, "  > Number of actual data race locations:\t\t" + totalDataRacePairLocations );
+        appendLn(
+                        sb,
+                        "  > Time to check all candidates:\t\t"
+                                        + ( checkingTimeDataRace / (double) 1000 )
+                                        + " seconds" );
+        appendLn( sb, "\n## MESSAGE RACES:" );
+        appendLn( sb, "  > Number of message race candidates:\t\t" + totalMsgRaceCandidates );
+        appendLn( sb, "  > Number of actual message races:\t\t" + totalMsgRacePairs );
+        appendLn(
+                        sb,
+                        "  > Time to check all message race candidates:\t\t"
+                                        + ( checkingTimeMsgRace / (double) 1000 )
+                                        + " seconds" );
+        return sb.toString();
+    }
 
-  private void appendLn(StringBuilder sb, String s) {
-    sb.append(s);
-    sb.append("\n");
-  }
+    private void appendLn( StringBuilder sb, String s )
+    {
+        sb.append( s );
+        sb.append( "\n" );
+    }
 }

--- a/src/main/java/pt/haslab/spider/solver/Solver.java
+++ b/src/main/java/pt/haslab/spider/solver/Solver.java
@@ -3,64 +3,72 @@ package pt.haslab.spider.solver;
 import java.io.IOException;
 import java.util.List;
 
-/** Created by nunomachado on 03/04/17. */
-public interface Solver {
+/**
+ * Created by nunomachado on 03/04/17.
+ */
+public interface Solver
+{
 
-  void init(String solverPath) throws IOException;
+    void init( String solverPath )
+                    throws IOException;
 
-  void close() throws IOException;
+    void close()
+                    throws IOException;
 
-  void flush() throws IOException;
+    void flush()
+                    throws IOException;
 
-  void writeConst(String constraint) throws IOException;
+    void writeConst( String constraint )
+                    throws IOException;
 
-  void writeComment(String comment) throws IOException;
+    void writeComment( String comment )
+                    throws IOException;
 
-  String cAnd(String exp1, String exp2);
+    String cAnd( String exp1, String exp2 );
 
-  String cAnd(String exp1);
+    String cAnd( String exp1 );
 
-  String cOr(String exp1, String exp2);
+    String cOr( String exp1, String exp2 );
 
-  String cOr(String exp1);
+    String cOr( String exp1 );
 
-  String cEq(String exp1, String exp2);
+    String cEq( String exp1, String exp2 );
 
-  String cNeq(String exp1, String exp2);
+    String cNeq( String exp1, String exp2 );
 
-  String cGeq(String exp1, String exp2);
+    String cGeq( String exp1, String exp2 );
 
-  String cGt(String exp1, String exp2);
+    String cGt( String exp1, String exp2 );
 
-  String cLeq(String exp1, String exp2);
+    String cLeq( String exp1, String exp2 );
 
-  String cLt(String exp1, String exp2);
+    String cLt( String exp1, String exp2 );
 
-  String cLt(String exp1);
+    String cLt( String exp1 );
 
-  String cDiv(String exp1, String exp2);
+    String cDiv( String exp1, String exp2 );
 
-  String cMod(String exp1, String exp2);
+    String cMod( String exp1, String exp2 );
 
-  String cPlus(String exp1, String exp2);
+    String cPlus( String exp1, String exp2 );
 
-  String cMinus(String exp1, String exp2);
+    String cMinus( String exp1, String exp2 );
 
-  String cMult(String exp1, String exp2);
+    String cMult( String exp1, String exp2 );
 
-  String cSummation(List<String> sum);
+    String cSummation( List<String> sum );
 
-  String cMinimize(String constraint);
+    String cMinimize( String constraint );
 
-  String cMaximize(String constraint);
+    String cMaximize( String constraint );
 
-  String declareIntVar(String varname);
+    String declareIntVar( String varname );
 
-  String declareIntVar(String varname, int min, int max);
+    String declareIntVar( String varname, int min, int max );
 
-  String declareIntVar(String varname, String min, String max);
+    String declareIntVar( String varname, String min, String max );
 
-  String postAssert(String constraint);
+    String postAssert( String constraint );
 
-  String postNamedAssert(String constraint, String label);
+    String postNamedAssert( String constraint, String label );
 }

--- a/src/main/java/pt/haslab/spider/solver/Z3SolverParallel.java
+++ b/src/main/java/pt/haslab/spider/solver/Z3SolverParallel.java
@@ -1,313 +1,412 @@
 package pt.haslab.spider.solver;
 
-import pt.haslab.taz.causality.CausalPair;
-import pt.haslab.taz.events.*;
 import pt.haslab.spider.Stats;
+import pt.haslab.taz.causality.CausalPair;
+import pt.haslab.taz.events.Event;
+import pt.haslab.taz.events.SocketEvent;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
-/** Created by nunomachado on 03/04/17. */
+/**
+ * Created by nunomachado on 03/04/17.
+ */
 
 // TODO: define an instance of Solver which uses the Z3 API instead of creating a new process
 
-public class Z3SolverParallel implements Solver {
-  private static Z3SolverParallel instance = null;
-  private static FileWriter outfile;
-  private static final String MODEL_FILENAME = "modelParallel.smt2";
-  private static int CORES;
-  private static Process[] z3Processes;
-  private static BufferedReader[] readers;
-  private static BufferedWriter[] writers;
-  private ConcurrentHashMap<Integer, CausalPair<? extends Event, ? extends Event>> racesFound;
+public class Z3SolverParallel
+                implements Solver
+{
+    private static Z3SolverParallel instance = null;
 
-  private Z3SolverParallel() {}
+    private static FileWriter outfile;
 
-  public static Z3SolverParallel getInstance() {
-    if (instance == null) {
-      instance = new Z3SolverParallel();
-    }
-    return instance;
-  }
+    private static final String MODEL_FILENAME = "modelParallel.smt2";
 
-  public void init(String solverPath) throws IOException {
-    CORES = Runtime.getRuntime().availableProcessors();
-    z3Processes = new Process[CORES];
-    readers = new BufferedReader[CORES];
-    writers = new BufferedWriter[CORES];
-    outfile = new FileWriter(new File(MODEL_FILENAME));
+    private static int CORES;
 
-    for (int i = 0; i < CORES; i++) {
-      ProcessBuilder builder = new ProcessBuilder(solverPath, "-smt2", "-in");
-      builder.redirectErrorStream(true);
-      z3Processes[i] = builder.start();
-      InputStream pout = z3Processes[i].getInputStream();
-      OutputStream pin = z3Processes[i].getOutputStream();
+    private static Process[] z3Processes;
 
-      readers[i] = new BufferedReader(new InputStreamReader(pout));
-      writers[i] = new BufferedWriter(new OutputStreamWriter(pin));
+    private static BufferedReader[] readers;
+
+    private static BufferedWriter[] writers;
+
+    private ConcurrentHashMap<Integer, CausalPair<? extends Event, ? extends Event>> racesFound;
+
+    private Z3SolverParallel()
+    {
     }
 
-    this.writeConst("(set-option :produce-unsat-cores true)");
-  }
-
-  public void close() throws IOException {
-    for (int i = 0; i < CORES; i++) {
-      z3Processes[i].destroy();
-    }
-    outfile.close();
-  }
-
-  public void flush() throws IOException {
-    outfile.flush();
-    for (int i = 0; i < CORES; i++) {
-      writers[i].flush();
-    }
-  }
-
-  public void writeConst(String constraint) throws IOException {
-    for (int i = 0; i < CORES; i++) {
-      writers[i].write(constraint + "\n");
-    }
-    outfile.write(constraint + "\n");
-  }
-
-  public void writeComment(String comment) throws IOException {
-    for (int i = 0; i < CORES; i++) {
-      writers[i].write("\n; " + comment + "\n");
-    }
-    outfile.write("\n; " + comment + "\n");
-  }
-
-  public HashSet<CausalPair<? extends Event, ? extends Event>> checkRacesParallel(
-      HashSet<CausalPair<? extends Event, ? extends Event>> candidates) {
-    try {
-      racesFound = new ConcurrentHashMap<>();
-      int batchsize = candidates.size() / CORES;
-      List<CausalPair<? extends Event, ? extends Event>> candidatesList =
-          new ArrayList<>(candidates);
-      WorkerZ3[] workers = new WorkerZ3[CORES];
-      int start = 0;
-      int end;
-      for (int i = 0; i < CORES; i++) {
-        if (i < CORES - 1) {
-          end = start + batchsize;
-        } else {
-          end = candidates.size();
+    public static Z3SolverParallel getInstance()
+    {
+        if ( instance == null )
+        {
+            instance = new Z3SolverParallel();
         }
-        WorkerZ3 w = new WorkerZ3(i, start, end, candidatesList);
-        workers[i] = w;
-        w.start();
-        start = end;
-      }
-      for (int i = 0; i < CORES; i++) {
-        workers[i].join();
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-    } finally {
-      return new HashSet<>(racesFound.values());
-    }
-  }
-
-  public String cAnd(String exp1, String exp2) {
-    return "(and " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cAnd(String exp1) {
-    return "(and " + exp1 + ")";
-  }
-
-  public String cOr(String exp1, String exp2) {
-    return "(or " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cOr(String exp1) {
-    return "(or " + exp1 + ")";
-  }
-
-  public String cEq(String exp1, String exp2) {
-    return "(= " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cNeq(String exp1, String exp2) {
-    return "(not (= " + exp1 + " " + exp2 + "))";
-  }
-
-  public String cGeq(String exp1, String exp2) {
-    return "(>= " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cGt(String exp1, String exp2) {
-    return "(> " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cLeq(String exp1, String exp2) {
-    return "(<= " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cLt(String exp1, String exp2) {
-    return "(< " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cLt(String exp1) {
-    return "(< " + exp1 + " )";
-  }
-
-  public String cDiv(String exp1, String exp2) {
-    return "(div " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cMod(String exp1, String exp2) {
-    return "(mod " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cPlus(String exp1, String exp2) {
-    return "(+ " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cMinus(String exp1, String exp2) {
-    return "(- " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cMult(String exp1, String exp2) {
-    return "(* " + exp1 + " " + exp2 + ")";
-  }
-
-  public String cSummation(List<String> sum) {
-    String res = "(+";
-    for (String s : sum) {
-      res += (" " + s);
-    }
-    res += ")";
-    return res;
-  }
-
-  public String cMinimize(String constraint) {
-    return "(minimize " + constraint + ")";
-  }
-
-  public String cMaximize(String constraint) {
-    return "(maximize " + constraint + ")";
-  }
-
-  public String declareIntVar(String varname) {
-    return "(declare-const " + varname + " Int)";
-  }
-
-  public String declareIntVar(String varname, int min, int max) {
-    String ret = ("(declare-const " + varname + " Int)\n");
-    ret += ("(assert (and (>= " + varname + " " + min + ") (<= " + varname + " " + max + ")))");
-    return ret;
-  }
-
-  public String declareIntVar(String varname, String min, String max) {
-    String ret = ("(declare-const " + varname + " Int)\n");
-    ret += ("(assert (and (>= " + varname + " " + min + ") (<= " + varname + " " + max + ")))");
-    return ret;
-  }
-
-  public String postAssert(String constraint) {
-    // synchronized (this) {
-    Stats.INSTANCE.numConstraints++;
-    // }
-    return ("(assert " + constraint + ")");
-  }
-
-  public String postNamedAssert(String constraint, String label) {
-    // synchronized (this) {
-    Stats.INSTANCE.numConstraints++;
-    // }
-    return ("(assert (! " + constraint + ":named " + label + Stats.INSTANCE.numConstraints + "))");
-  }
-
-  private String push() {
-    return "(push)";
-  }
-
-  private String pop() {
-    return "(pop)";
-  }
-
-  private String checkSat() {
-    return "(check-sat)";
-  }
-
-  class WorkerZ3 extends Thread {
-    private int id;
-    private int startPos;
-    private int endPos;
-    List<CausalPair<? extends Event, ? extends Event>> candidates;
-
-    WorkerZ3(
-        int tid,
-        int start,
-        int end,
-        List<CausalPair<? extends Event, ? extends Event>> candidatePairs) {
-      id = tid;
-      startPos = start;
-      endPos = end;
-      candidates = candidatePairs;
+        return instance;
     }
 
-    @Override
-    public void run() {
-      try {
-        System.out.println(
-            "["
-                + id
-                + "] Started worker for batch ["
-                + startPos
-                + ", "
-                + endPos
-                + "]\t(z3 process "
-                + z3Processes[id]
-                + ")");
+    public void init( String solverPath )
+                    throws IOException
+    {
+        CORES = Runtime.getRuntime().availableProcessors();
+        z3Processes = new Process[CORES];
+        readers = new BufferedReader[CORES];
+        writers = new BufferedWriter[CORES];
+        outfile = new FileWriter( new File( MODEL_FILENAME ) );
 
-        // check data races for a portion of the list
-        for (int i = startPos; i < endPos; i++) {
-          CausalPair<? extends Event, ? extends Event> candidate = candidates.get(i);
-          boolean isMsgRace = (candidate.getFirst() instanceof SocketEvent);
-          boolean isConflict =
-              checkRace(
-                  candidate.getFirst().toString(), candidate.getSecond().toString(), isMsgRace);
-          if (isConflict) {
-            racesFound.put(candidate.hashCode(), candidate);
-          }
+        for ( int i = 0; i < CORES; i++ )
+        {
+            ProcessBuilder builder = new ProcessBuilder( solverPath, "-smt2", "-in" );
+            builder.redirectErrorStream( true );
+            z3Processes[i] = builder.start();
+            InputStream pout = z3Processes[i].getInputStream();
+            OutputStream pin = z3Processes[i].getOutputStream();
+
+            readers[i] = new BufferedReader( new InputStreamReader( pout ) );
+            writers[i] = new BufferedWriter( new OutputStreamWriter( pin ) );
         }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+
+        this.writeConst( "(set-option :produce-unsat-cores true)" );
     }
 
-    boolean checkRace(String e1, String e2, boolean isMsgRace) {
-      try {
-        writers[id].write(push() + "\n");
-        String conflictConst;
-        if (isMsgRace) conflictConst = postNamedAssert(cLt(e1, e2), "RACE");
-        else conflictConst = postNamedAssert(cEq(e1, e2), "RACE");
-        // System.out.println("CONSTRAINT: "+conflictConst);
-        writers[id].write(conflictConst + "\n");
-        writers[id].write(checkSat() + "\n");
-        writers[id].write(pop() + "\n");
-        writers[id].flush();
-
-        String isConflict;
-        do {
-          isConflict = readers[id].readLine();
-          // System.out.println(isConflict);
-          if (isConflict.contains("error"))
-            System.out.println(e1 + " " + e2 + " --> " + isConflict);
-        } while (isConflict.contains("error"));
-
-        return (isConflict.equals("sat"));
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-      return false;
+    public void close()
+                    throws IOException
+    {
+        for ( int i = 0; i < CORES; i++ )
+        {
+            z3Processes[i].destroy();
+        }
+        outfile.close();
     }
-  }
+
+    public void flush()
+                    throws IOException
+    {
+        outfile.flush();
+        for ( int i = 0; i < CORES; i++ )
+        {
+            writers[i].flush();
+        }
+    }
+
+    public void writeConst( String constraint )
+                    throws IOException
+    {
+        for ( int i = 0; i < CORES; i++ )
+        {
+            writers[i].write( constraint + "\n" );
+        }
+        outfile.write( constraint + "\n" );
+    }
+
+    public void writeComment( String comment )
+                    throws IOException
+    {
+        for ( int i = 0; i < CORES; i++ )
+        {
+            writers[i].write( "\n; " + comment + "\n" );
+        }
+        outfile.write( "\n; " + comment + "\n" );
+    }
+
+    public HashSet<CausalPair<? extends Event, ? extends Event>> checkRacesParallel(
+                    HashSet<CausalPair<? extends Event, ? extends Event>> candidates )
+    {
+        try
+        {
+            racesFound = new ConcurrentHashMap<>();
+            int batchsize = candidates.size() / CORES;
+            List<CausalPair<? extends Event, ? extends Event>> candidatesList =
+                            new ArrayList<>( candidates );
+            WorkerZ3[] workers = new WorkerZ3[CORES];
+            int start = 0;
+            int end;
+            for ( int i = 0; i < CORES; i++ )
+            {
+                if ( i < CORES - 1 )
+                {
+                    end = start + batchsize;
+                }
+                else
+                {
+                    end = candidates.size();
+                }
+                WorkerZ3 w = new WorkerZ3( i, start, end, candidatesList );
+                workers[i] = w;
+                w.start();
+                start = end;
+            }
+            for ( int i = 0; i < CORES; i++ )
+            {
+                workers[i].join();
+            }
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+        }
+        finally
+        {
+            return new HashSet<>( racesFound.values() );
+        }
+    }
+
+    public String cAnd( String exp1, String exp2 )
+    {
+        return "(and " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cAnd( String exp1 )
+    {
+        return "(and " + exp1 + ")";
+    }
+
+    public String cOr( String exp1, String exp2 )
+    {
+        return "(or " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cOr( String exp1 )
+    {
+        return "(or " + exp1 + ")";
+    }
+
+    public String cEq( String exp1, String exp2 )
+    {
+        return "(= " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cNeq( String exp1, String exp2 )
+    {
+        return "(not (= " + exp1 + " " + exp2 + "))";
+    }
+
+    public String cGeq( String exp1, String exp2 )
+    {
+        return "(>= " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cGt( String exp1, String exp2 )
+    {
+        return "(> " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cLeq( String exp1, String exp2 )
+    {
+        return "(<= " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cLt( String exp1, String exp2 )
+    {
+        return "(< " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cLt( String exp1 )
+    {
+        return "(< " + exp1 + " )";
+    }
+
+    public String cDiv( String exp1, String exp2 )
+    {
+        return "(div " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cMod( String exp1, String exp2 )
+    {
+        return "(mod " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cPlus( String exp1, String exp2 )
+    {
+        return "(+ " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cMinus( String exp1, String exp2 )
+    {
+        return "(- " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cMult( String exp1, String exp2 )
+    {
+        return "(* " + exp1 + " " + exp2 + ")";
+    }
+
+    public String cSummation( List<String> sum )
+    {
+        String res = "(+";
+        for ( String s : sum )
+        {
+            res += ( " " + s );
+        }
+        res += ")";
+        return res;
+    }
+
+    public String cMinimize( String constraint )
+    {
+        return "(minimize " + constraint + ")";
+    }
+
+    public String cMaximize( String constraint )
+    {
+        return "(maximize " + constraint + ")";
+    }
+
+    public String declareIntVar( String varname )
+    {
+        return "(declare-const " + varname + " Int)";
+    }
+
+    public String declareIntVar( String varname, int min, int max )
+    {
+        String ret = ( "(declare-const " + varname + " Int)\n" );
+        ret += ( "(assert (and (>= " + varname + " " + min + ") (<= " + varname + " " + max + ")))" );
+        return ret;
+    }
+
+    public String declareIntVar( String varname, String min, String max )
+    {
+        String ret = ( "(declare-const " + varname + " Int)\n" );
+        ret += ( "(assert (and (>= " + varname + " " + min + ") (<= " + varname + " " + max + ")))" );
+        return ret;
+    }
+
+    public String postAssert( String constraint )
+    {
+        // synchronized (this) {
+        Stats.INSTANCE.numConstraints++;
+        // }
+        return ( "(assert " + constraint + ")" );
+    }
+
+    public String postNamedAssert( String constraint, String label )
+    {
+        // synchronized (this) {
+        Stats.INSTANCE.numConstraints++;
+        // }
+        return ( "(assert (! " + constraint + ":named " + label + Stats.INSTANCE.numConstraints + "))" );
+    }
+
+    private String push()
+    {
+        return "(push)";
+    }
+
+    private String pop()
+    {
+        return "(pop)";
+    }
+
+    private String checkSat()
+    {
+        return "(check-sat)";
+    }
+
+    class WorkerZ3
+                    extends Thread
+    {
+        private int id;
+
+        private int startPos;
+
+        private int endPos;
+
+        List<CausalPair<? extends Event, ? extends Event>> candidates;
+
+        WorkerZ3(
+                        int tid,
+                        int start,
+                        int end,
+                        List<CausalPair<? extends Event, ? extends Event>> candidatePairs )
+        {
+            id = tid;
+            startPos = start;
+            endPos = end;
+            candidates = candidatePairs;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                System.out.println(
+                                "["
+                                                + id
+                                                + "] Started worker for batch ["
+                                                + startPos
+                                                + ", "
+                                                + endPos
+                                                + "]\t(z3 process "
+                                                + z3Processes[id]
+                                                + ")" );
+
+                // check data races for a portion of the list
+                for ( int i = startPos; i < endPos; i++ )
+                {
+                    CausalPair<? extends Event, ? extends Event> candidate = candidates.get( i );
+                    boolean isMsgRace = ( candidate.getFirst() instanceof SocketEvent );
+                    boolean isConflict =
+                                    checkRace(
+                                                    candidate.getFirst().toString(), candidate.getSecond().toString(),
+                                                    isMsgRace );
+                    if ( isConflict )
+                    {
+                        racesFound.put( candidate.hashCode(), candidate );
+                    }
+                }
+            }
+            catch ( Exception e )
+            {
+                e.printStackTrace();
+            }
+        }
+
+        boolean checkRace( String e1, String e2, boolean isMsgRace )
+        {
+            try
+            {
+                writers[id].write( push() + "\n" );
+                String conflictConst;
+                if ( isMsgRace )
+                    conflictConst = postNamedAssert( cLt( e1, e2 ), "RACE" );
+                else
+                    conflictConst = postNamedAssert( cEq( e1, e2 ), "RACE" );
+                // System.out.println("CONSTRAINT: "+conflictConst);
+                writers[id].write( conflictConst + "\n" );
+                writers[id].write( checkSat() + "\n" );
+                writers[id].write( pop() + "\n" );
+                writers[id].flush();
+
+                String isConflict;
+                do
+                {
+                    isConflict = readers[id].readLine();
+                    // System.out.println(isConflict);
+                    if ( isConflict.contains( "error" ) )
+                        System.out.println( e1 + " " + e2 + " --> " + isConflict );
+                }
+                while ( isConflict.contains( "error" ) );
+
+                return ( isConflict.equals( "sat" ) );
+            }
+            catch ( Exception e )
+            {
+                e.printStackTrace();
+            }
+            return false;
+        }
+    }
 }

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,13 +1,11 @@
 ### set log levels - for more verbose logging change 'info' to 'debug' ###
 ### Also add logfile to the root, if need stdout then add stdout appender here###
 log4j.rootLogger=debug, stdout
-
 #  logger option
 log4j.logger.pt.haslab.taz.TraceProcessor=INFO, taz
 log4j.appender.taz=org.apache.log4j.ConsoleAppender
 log4j.appender.taz.layout=org.apache.log4j.PatternLayout
 log4j.appender.taz.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
-
 ### direct log messages to stdout ###
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/src/test/java/pt/haslab/spider/CheckerParallelTest.java
+++ b/src/test/java/pt/haslab/spider/CheckerParallelTest.java
@@ -9,31 +9,34 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class CheckerParallelTest {
+class CheckerParallelTest
+{
 
-  // Even though this code does not belong to this library,
-  // it is important to make sure it gives the intended functionality.
-  @Test
-  void testCatIterator() {
-    List<Integer> a = IntStream.of(1, 4, 7).boxed().collect(Collectors.toList());
-    List<Integer> b = IntStream.of(2, 5, 8).boxed().collect(Collectors.toList());
-    List<Integer> c = IntStream.of(3, 6, 9).boxed().collect(Collectors.toList());
-    List<List<Integer>> aggregate = Stream.of(c, b, a).collect(Collectors.toList());
+    // Even though this code does not belong to this library,
+    // it is important to make sure it gives the intended functionality.
+    @Test
+    void testCatIterator()
+    {
+        List<Integer> a = IntStream.of( 1, 4, 7 ).boxed().collect( Collectors.toList() );
+        List<Integer> b = IntStream.of( 2, 5, 8 ).boxed().collect( Collectors.toList() );
+        List<Integer> c = IntStream.of( 3, 6, 9 ).boxed().collect( Collectors.toList() );
+        List<List<Integer>> aggregate = Stream.of( c, b, a ).collect( Collectors.toList() );
 
-    List<Integer> expectedResult =
-        IntStream.of(1, 2, 3, 4, 5, 6, 7, 8, 9).boxed().collect(Collectors.toList());
+        List<Integer> expectedResult =
+                        IntStream.of( 1, 2, 3, 4, 5, 6, 7, 8, 9 ).boxed().collect( Collectors.toList() );
 
-    CatIterator<Integer> catIterator = new CatIterator<>(aggregate);
-    List<Integer> concatList = new ArrayList<>();
-    catIterator.forEachRemaining(concatList::add);
+        CatIterator<Integer> catIterator = new CatIterator<>( aggregate );
+        List<Integer> concatList = new ArrayList<>();
+        catIterator.forEachRemaining( concatList::add );
 
-    assertEquals(concatList, expectedResult);
-  }
+        assertEquals( concatList, expectedResult );
+    }
 
-  @Test
-  void testSortedSetToList() {
-    // TODO
-  }
+    @Test
+    void testSortedSetToList()
+    {
+        // TODO
+    }
 }


### PR DESCRIPTION
This PR addresses [issue #28](https://github.com/jcp19/SPIDER/issues/28) by encoding the strong rev-handler linkage constraints. In addition, the PR reformats the code to follow the [maven code style](https://maven.apache.org/developers/conventions/code.html). 

Let `R` be a Rcv event and `H` the set of handlers belonging to the same thread of R and the same socket. The receive-handler linkage constraints state that `for all h_i \in H`:
```
R = hBegin_i
   &&  hEnd_i < {event next to R in the thread timeline}
   &&  ( for all {h_j \in H, h_j != h_i}: hEnd_i < hBegin_j || hEnd_j < hBegin_i )
```
    
Briefly speaking, the constraints state that `R` has to be mapped to one and only one handler. In particular, if `R` is mapped to `h_i`, then all other `h_j` occur either before or after `h_i`.


**Note:** The current version of the constraints render the model too complex and heavy to solve in practical time. We should consider implementing optimizations.